### PR TITLE
CI configs

### DIFF
--- a/.github/scripts/ci-setup.sh
+++ b/.github/scripts/ci-setup.sh
@@ -1,12 +1,14 @@
 set -xe
 
-export RUST_VERSION=nightly-2019-08-26
-
 # Install nightly rust
-rustup toolchain install $RUST_VERSION
-rustup target add i686-unknown-linux-gnu --toolchain $RUST_VERSION
-rustup override set $RUST_VERSION
+rustup toolchain install $RUSTUP_TOOLCHAIN
+rustup target add i686-unknown-linux-gnu --toolchain $RUSTUP_TOOLCHAIN
+rustup override set $RUSTUP_TOOLCHAIN
 
 # Download dacapo
 mkdir -p repos/openjdk/benchmarks
 wget https://downloads.sourceforge.net/project/dacapobench/archive/2006-10-MR2/dacapo-2006-10-MR2.jar -O repos/openjdk/benchmarks/dacapo-2006-10-MR2.jar
+
+# Install dependencies
+sudo apt-get update -y
+sudo apt-get install build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev

--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -1,14 +1,55 @@
 set -xe
 
 # To OpenJDK folder
-cd mmtk-openjdk/repos/openjdk
+cd repos/openjdk
 
-# Set DEBUG_LEVEL
-export DEBUG_LEVEL=fastdebug
+# Release build
+export DEBUG_LEVEL=release
+echo $RUSTUP_TOOLCHAIN
 
-# config and build SemiSpace
+# --- SemiSpace ---
+
+# Build
 export MMTK_PLAN=semispace
 sh configure --disable-warnings-as-errors --with-debug-level=$DEBUG_LEVEL
+make CONF=linux-x86_64-normal-server-$DEBUG_LEVEL THIRD_PARTY_HEAP=$PWD/../../openjdk
 
-# Test
-./build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -jar benchmarks/dacapo-2006-10-MR2.jar fop
+# Test - the benchmarks that are commented out do not work yet
+# Note: the command line options are necessary for now to ensure the benchmarks work. We may later change the options if we do not have these many constraints.
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar antlr
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar bloat - does not work for stock build
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar eclipse
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar fop
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar hsqldb
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar jython - does not work for stock build
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar luindex
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar lusearch - validation failed
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar pmd
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar xalan
+
+# Cleanup the build
+rm -r ./build/linux-x86_64-normal-server-$DEBUG_LEVEL
+
+# --- NoGC ---
+
+# Build
+export MMTK_PLAN=nogc
+sh configure --disable-warnings-as-errors --with-debug-level=$DEBUG_LEVEL
+make CONF=linux-x86_64-normal-server-$DEBUG_LEVEL THIRD_PARTY_HEAP=$PWD/../../openjdk
+
+# Test - the benchmarks that are commented out do not work yet
+# Note: We could increase heap size when mmtk core can work for larger heap. We may get more benchmarks running.
+
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar antlr
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar bloat - does not work for stock build
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar eclipes - OOM
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar fop
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar hsqldb - OOM
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar jython - does not work for stock build
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar luindex
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar lusearch - OOM
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar pmd - OOM
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar xalan - OOM
+
+# Cleanup the build
+rm -r ./build/linux-x86_64-normal-server-$DEBUG_LEVEL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
       - name: Setup Environments
-        run: ./.github/scripts/ci-setup.sh
+        run: RUSTUP_TOOLCHAIN=nightly-2019-08-26 ./.github/scripts/ci-setup.sh
 
       # Run the tests
       - name: Dacapo Tests
-        run: ./.github/scripts/ci-test.sh
+        run: RUSTUP_TOOLCHAIN=nightly-2019-08-26 ./.github/scripts/ci-test.sh

--- a/openjdk/CompileThirdPartyHeap.gmk
+++ b/openjdk/CompileThirdPartyHeap.gmk
@@ -2,7 +2,11 @@
 MMTK_RUST_ROOT = $(TOPDIR)/../../mmtk
 MMTK_CPP_ROOT = $(TOPDIR)/../../openjdk
 
-GC := $(MMTK_PLAN)
+ifndef MMTK_PLAN
+  GC=semispace
+else
+  GC=$(MMTK_PLAN)
+endif
 
 LIB_MMTK := $(JVM_LIB_OUTPUTDIR)/libmmtk_openjdk.so
 
@@ -13,8 +17,14 @@ else
   CARGO_PROFILE = debug
 endif
 
+ifndef RUSTUP_TOOLCHAIN
+  CARGO_VERSION=
+else
+  CARGO_VERSION=+$(RUSTUP_TOOLCHAIN)
+endif
+
 $(LIB_MMTK): FORCE
-	cargo +nightly build --manifest-path=$(MMTK_RUST_ROOT)/Cargo.toml $(CARGO_PROFILE_FLAG) --features $(GC)
+	cargo $(CARGO_VERSION) build --manifest-path=$(MMTK_RUST_ROOT)/Cargo.toml $(CARGO_PROFILE_FLAG) --features $(GC)
 	cp $(MMTK_RUST_ROOT)/target/$(CARGO_PROFILE)/libmmtk_openjdk.so $(LIB_MMTK)
 
 JVM_LIBS += -L$(JVM_LIB_OUTPUTDIR) -lmmtk_openjdk


### PR DESCRIPTION
* Add scripts to run dacapo tests. 
* Add configs for correctness CI.
* Add `MMTK_PLAN` and `RUSTUP_TOOLCHAIN` for build with different plans and toolchains. Note that `RUSTUP_TOOLCHAIN=nightly` is required unless nightly is the default toolchain. 