### PR TITLE
Set credential for cargo dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
           # CI_ACCESS_TOKEN is a secret set with the repo
           token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
+      - name: Set credential for cargo dependency
+        run: sed -i 's/ssh:\/\/git@github.com\/mmtk/https:\/\/qinsoon:${{ secrets.CI_ACCESS_TOKEN }}@github.com\/mmtk/g' mmtk/Cargo.toml
       - name: Setup Environments
         run: RUSTUP_TOOLCHAIN=nightly-2019-08-26 ./.github/scripts/ci-setup.sh
 


### PR DESCRIPTION
* Fix the credential issue after changing from git submodule to crate dependency. 
* The CI got stuck during executing `xalan` (probably we still want to run mmtk with release build). 