### PR TITLE
Improving root scanning performance

### DIFF
--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -90,6 +90,14 @@ pub extern "C" fn report_delayed_root_edge(trace_local: *mut SelectedTraceLocal<
 }
 
 #[no_mangle]
+pub extern "C" fn bulk_report_delayed_root_edge(trace_local: *mut SelectedTraceLocal<OpenJDK>, buffer: *const Address, length: usize) {
+    let trace_local = unsafe { &mut *trace_local };
+    for i in 0..length {
+        memory_manager::report_delayed_root_edge(&SINGLETON, trace_local, unsafe { *buffer.add(i) })
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn will_not_move_in_current_collection(trace_local: *mut SelectedTraceLocal<OpenJDK>, obj: ObjectReference) -> bool {
     memory_manager::will_not_move_in_current_collection(&SINGLETON, unsafe { &mut *trace_local}, obj)
 }

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -40,6 +40,9 @@ extern void modify_check(void* ref);
 extern void report_delayed_root_edge(MMTk_TraceLocal trace_local,
                                      void* addr);
 
+extern void bulk_report_delayed_root_edge(MMTk_TraceLocal trace_local,
+                                          void** buffer, size_t length);
+
 extern bool will_not_move_in_current_collection(MMTk_TraceLocal trace_local,
                                                 void* obj);
 


### PR DESCRIPTION
This PR fixes https://github.com/mmtk/mmtk-core/issues/118.

The old way of reporting root edges is to call `report_delayed_root_edge` once for each root edge, to transfer the root edge to MMTk.

During root scanning phases (including stack, global and static roots), the OpenJDK binding now pushes every discovered root edges into thread-local buffers (one for each collector thread). The buffer will be sent to MMTk after it's filled. This reduces the frequency of FFI calls into the MMTk library and hence improves the root scanning performance.

---

It seems that we don't need to do anything to [mmtk-core](https://github.com/mmtk/mmtk-core). The fix can be done entirely within the vm-binding.

