### PR TITLE
Fix the bound check is_in()

### DIFF
--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -163,7 +163,7 @@ bool MMTkHeap::is_in(const void* p) const {
    //return cp >= committed_low_addr() && cp < committed_high_addr();
 
    //guarantee(false, "is in not supported");
-    return p > (void*) _start && p < (void*) _end;
+    return p >= (void*) _start && p < (void*) _end;
 }
 
 bool MMTkHeap::is_in_reserved(const void* p) const {


### PR DESCRIPTION
This fixes https://github.com/mmtk/mmtk-openjdk/issues/33.