### PR TITLE
Fix random failure due to duplicate unaligned root edges

### DIFF
--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -414,8 +414,7 @@ void MMTkHeap::scan_weak_processor_roots(OopClosure& cl) {
 void MMTkHeap::scan_vm_thread_roots(OopClosure& cl) {
    ResourceMark rm;
    MMTkRootScanWorkScope<> root_scan_work(&_num_root_scan_tasks);
-   CodeBlobToOopClosure cb_cl(&cl, false);
-   VMThread::vm_thread()->oops_do(&cl, &cb_cl);
+   VMThread::vm_thread()->oops_do(&cl, NULL);
 }
 
 void MMTkHeap::scan_global_roots(OopClosure& cl) {

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -448,9 +448,7 @@ void MMTkHeap::scan_global_roots(OopClosure& cl) {
 void MMTkHeap::scan_thread_roots(OopClosure& cl) {
    ResourceMark rm;
    MMTkRootScanWorkScope<> root_scan_work(&_num_root_scan_tasks);
-
-   CodeBlobToOopClosure cb_cl(&cl, false);
-   Threads::possibly_parallel_oops_do(false, &cl, &cb_cl);
+   Threads::possibly_parallel_oops_do(false, &cl, NULL);
 }
 
 void MMTkHeap::scan_roots(OopClosure& cl) {

--- a/openjdk/mmtkUpcalls.cpp
+++ b/openjdk/mmtkUpcalls.cpp
@@ -164,8 +164,7 @@ static void mmtk_scan_thread_root(ProcessEdgesFn process_edges, void* tls) {
     ResourceMark rm;
     JavaThread* thread = (JavaThread*) tls;
     MMTkRootsClosure2 cl(process_edges);
-    CodeBlobToOopClosure cb_cl(&cl, false);
-    thread->oops_do(&cl, &cb_cl);
+    thread->oops_do(&cl, NULL);
 }
 
 static void mmtk_scan_object(void* trace, void* object, void* tls) {


### PR DESCRIPTION
This PR fixes https://github.com/mmtk/mmtk-openjdk/issues/11 and https://github.com/mmtk/mmtk-openjdk/issues/12 by reducing duplicate `CodeBlob` root edges.

Fix #11 
Fix #12 