### PR TITLE
rebase to the openjdk/jdk11u repo

### DIFF
--- a/.github/scripts/ci-setup.sh
+++ b/.github/scripts/ci-setup.sh
@@ -13,4 +13,4 @@ wget https://downloads.sourceforge.net/project/dacapobench/archive/2006-10-MR2/d
 
 # Install dependencies
 sudo apt-get update -y
-sudo apt-get install build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev
+sudo apt-get install build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "repos/openjdk"]
 	path = repos/openjdk
 	url = git@github.com:mmtk/openjdk.git
-	branch = jdk-11+28-mmtk
+	branch = jdk-11.0.11+6-mmtk


### PR DESCRIPTION
This PR rebases our openjdk fork (`mmtk/openjdk`) to the latest OpenJDK 11 commit from the JDK 11 update repo here:

https://github.com/openjdk/jdk11u.git

The new OpenJDK fork is under the branch name `jdk-11.0.11+6-mmtk`