### PR TITLE
Remove MMTK_PLAN from CompileThirdPartyHeap

### DIFF
--- a/openjdk/CompileThirdPartyHeap.gmk
+++ b/openjdk/CompileThirdPartyHeap.gmk
@@ -2,10 +2,6 @@
 MMTK_RUST_ROOT = $(TOPDIR)/../../mmtk
 MMTK_CPP_ROOT = $(TOPDIR)/../../openjdk
 
-ifdef MMTK_PLAN
-  GC_FEATURES=--features $(MMTK_PLAN)
-endif
-
 LIB_MMTK := $(JVM_LIB_OUTPUTDIR)/libmmtk_openjdk.so
 
 ifeq ($(DEBUG_LEVEL), release)


### PR DESCRIPTION
Since we have runtime plan selection support now, this option doesn't make sense anymore.