### PR TITLE
Alloc to LOS for large objects

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "49c4e338aca633e558a6b351fa2bfc0ecf39c8a0" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "ff5308349727cc503979cf312ffe25cd20c462b9" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "ff5308349727cc503979cf312ffe25cd20c462b9" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "def6b87d31ecec1e92acfe502e1f349b4c51859f" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "def6b87d31ecec1e92acfe502e1f349b4c51859f" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "0875c9084fc11114f122f4f4d59d27f2ceeae07b" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "ad824527bc7fa87dfba66cc2cd8745ad1c331b9f" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "f0a4138c525d7285802b582cba69286f9737dfc1" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "f0a4138c525d7285802b582cba69286f9737dfc1" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "825cb23ace807bee6802a7c5b3e06d9a87c5ccd8" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "f6d81c3dc871c6c3d36af006280f738b2d2767b3" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "af84ff04ab160dc662de9efd3140458182543a50" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -93,7 +93,10 @@ pub extern "C" fn get_allocator_mapping(allocator: AllocationSemantics) -> Alloc
 
 #[no_mangle]
 pub extern "C" fn get_max_non_los_default_alloc_bytes() -> usize {
-    SINGLETON.get_plan().constraints().max_non_los_default_alloc_bytes
+    SINGLETON
+        .get_plan()
+        .constraints()
+        .max_non_los_default_alloc_bytes
 }
 
 #[no_mangle]

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -92,6 +92,11 @@ pub extern "C" fn get_allocator_mapping(allocator: AllocationSemantics) -> Alloc
 }
 
 #[no_mangle]
+pub extern "C" fn get_max_non_los_default_alloc_bytes() -> usize {
+    SINGLETON.get_plan().constraints().max_non_los_default_alloc_bytes
+}
+
+#[no_mangle]
 // We trust the mutator pointer is valid.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn post_alloc(

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -20,11 +20,6 @@ impl ObjectModel<OpenJDK> for VMObjectModel {
         copy_context: &mut impl CopyContext,
     ) -> ObjectReference {
         let bytes = unsafe { ((*UPCALLS).get_object_size)(from) };
-        assert!(
-            bytes <= super::api::get_max_non_los_default_alloc_bytes(),
-            "trying to copy object of {} bytes, it should not be allocated into copy space",
-            bytes
-        );
         let dst =
             copy_context.alloc_copy(from, bytes, ::std::mem::size_of::<usize>(), 0, allocator);
         // Copy

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -20,7 +20,11 @@ impl ObjectModel<OpenJDK> for VMObjectModel {
         copy_context: &mut impl CopyContext,
     ) -> ObjectReference {
         let bytes = unsafe { ((*UPCALLS).get_object_size)(from) };
-        assert!(bytes <= super::api::get_max_non_los_default_alloc_bytes(), "trying to copy object of {} bytes, it should not be allocated into copy space", bytes);
+        assert!(
+            bytes <= super::api::get_max_non_los_default_alloc_bytes(),
+            "trying to copy object of {} bytes, it should not be allocated into copy space",
+            bytes
+        );
         let dst =
             copy_context.alloc_copy(from, bytes, ::std::mem::size_of::<usize>(), 0, allocator);
         // Copy

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -20,6 +20,7 @@ impl ObjectModel<OpenJDK> for VMObjectModel {
         copy_context: &mut impl CopyContext,
     ) -> ObjectReference {
         let bytes = unsafe { ((*UPCALLS).get_object_size)(from) };
+        assert!(bytes <= super::api::get_max_non_los_default_alloc_bytes(), "trying to copy object of {} bytes, it should not be allocated into copy space", bytes);
         let dst =
             copy_context.alloc_copy(from, bytes, ::std::mem::size_of::<usize>(), 0, allocator);
         // Copy

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -51,6 +51,7 @@ struct AllocatorSelector {
 #define TAG_MALLOC          2
 
 extern AllocatorSelector get_allocator_mapping(int allocator);
+extern size_t get_max_non_los_default_alloc_bytes();
 
 /**
  * Finalization

--- a/openjdk/mmtkBarrierSetAssembler_x86.cpp
+++ b/openjdk/mmtkBarrierSetAssembler_x86.cpp
@@ -45,7 +45,8 @@ void MMTkBarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register threa
     // Note that OpenJDK has a slow path check. Search for layout_helper_needs_slow_path and FastAllocateSizeLimit.
     // I tried to set FastAllocateSizeLimit in MMTkHeap::initialize(). But there are still large objects allocated into the
     // default space.
-    size_t max_non_los_bytes = get_max_non_los_default_alloc_bytes();
+    assert(MMTkMutatorContext::max_non_los_default_alloc_bytes != 0, "max_non_los_default_alloc_bytes hasn't been initialized");
+    size_t max_non_los_bytes = MMTkMutatorContext::max_non_los_default_alloc_bytes;
     if (var_size_in_bytes == noreg) {
       // constant alloc size. If it is larger than max_non_los_bytes, we directly go to slowpath.
       if ((size_t)con_size_in_bytes > max_non_los_bytes) {

--- a/openjdk/mmtkBarrierSetC2.cpp
+++ b/openjdk/mmtkBarrierSetC2.cpp
@@ -48,7 +48,6 @@ void MMTkBarrierSetC2::expand_allocate(
             address slow_call_address  // Address of slow call
     )
 {
-  // assert(false, "c2 is used");
   Node* ctrl = alloc->in(TypeFunc::Control);
   Node* mem  = alloc->in(TypeFunc::Memory);
   Node* i_o  = alloc->in(TypeFunc::I_O);

--- a/openjdk/mmtkBarrierSetC2.cpp
+++ b/openjdk/mmtkBarrierSetC2.cpp
@@ -80,7 +80,8 @@ void MMTkBarrierSetC2::expand_allocate(
   // should be evaluated to true, and we jump to the slowpath.
 
   // The max non-los bytes from MMTk
-  size_t max_non_los_bytes = get_max_non_los_default_alloc_bytes();
+  assert(MMTkMutatorContext::max_non_los_default_alloc_bytes != 0, "max_non_los_default_alloc_bytes hasn't been initialized");
+  size_t max_non_los_bytes = MMTkMutatorContext::max_non_los_default_alloc_bytes;
   // Check if allocation size is constant
   long const_size = x->_igvn.find_long_con(size_in_bytes, -1);
   if (const_size >= 0) {

--- a/openjdk/mmtkBarrierSetC2.cpp
+++ b/openjdk/mmtkBarrierSetC2.cpp
@@ -80,12 +80,12 @@ void MMTkBarrierSetC2::expand_allocate(
   // should be evaluated to true, and we jump to the slowpath.
 
   // The max non-los bytes from MMTk
-  int max_non_los_bytes = (int)get_max_non_los_default_alloc_bytes();
+  size_t max_non_los_bytes = get_max_non_los_default_alloc_bytes();
   // Check if allocation size is constant
-  int const_size = x->_igvn.find_int_con(size_in_bytes, -1);
+  long const_size = x->_igvn.find_long_con(size_in_bytes, -1);
   if (const_size >= 0) {
-    // Constant alloc size
-    if (const_size > max_non_los_bytes) {
+    // Constant alloc size. We know it is non-negative, it is safe to cast to unsigned long and compare with size_t
+    if (((unsigned long)const_size) > max_non_los_bytes) {
       // We know at JIT time that we need to go to slowpath
       always_slow = true;
       initial_slow_test = NULL;

--- a/openjdk/mmtkBarrierSetC2.cpp
+++ b/openjdk/mmtkBarrierSetC2.cpp
@@ -48,7 +48,7 @@ void MMTkBarrierSetC2::expand_allocate(
             address slow_call_address  // Address of slow call
     )
 {
-  assert(false, "c2 is used");
+  // assert(false, "c2 is used");
   Node* ctrl = alloc->in(TypeFunc::Control);
   Node* mem  = alloc->in(TypeFunc::Memory);
   Node* i_o  = alloc->in(TypeFunc::I_O);

--- a/openjdk/mmtkBarrierSetC2.cpp
+++ b/openjdk/mmtkBarrierSetC2.cpp
@@ -87,7 +87,8 @@ void MMTkBarrierSetC2::expand_allocate(
     // Constant alloc size
     if (const_size > max_non_los_bytes) {
       // We know at JIT time that we need to go to slowpath
-      initial_slow_test = x->intcon(1);
+      always_slow = true;
+      initial_slow_test = NULL;
     }
   } else {
     // Variable alloc size
@@ -108,9 +109,9 @@ void MMTkBarrierSetC2::expand_allocate(
       // If there is existing initial_slow_test, we combine the result by 'or' them together.
 
       // Conditionally move a value 1 or 0 depends on the size check.
-      // This is definitely not optimal. But to make things simple and to avoid changing the control flow,
-      // this is the only way I can think up with. But it seems it does not affect performance much
-      // (maybe this branch does not get generated often?).
+      // This is definitely not optimal. But to make things simple and to avoid changing the original
+      // control flow, it is much easier to implement with a cmov. And it should not affect performance much,
+      // as var size allocation is rare.
       Node *mmtk_size_cmov = new CMoveINode(mmtk_size_bool, x->intcon(0), x->intcon(1), TypeInt::INT);
       x->transform_later(mmtk_size_cmov);
 

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -77,6 +77,8 @@ jint MMTkHeap::initialize() {
     /*forcefully*/ //mmtk_heap_size = (1<<31) -1;
 
     openjdk_gc_init(&mmtk_upcalls, mmtk_heap_size);
+    // Cache the value here. It is a constant depending on the selected plan. The plan won't change from now, so value won't change.
+    MMTkMutatorContext::max_non_los_default_alloc_bytes = get_max_non_los_default_alloc_bytes();
 
     //ReservedSpace heap_rs = Universe::reserve_heap(mmtk_heap_size, _collector_policy->heap_alignment());
 

--- a/openjdk/mmtkMutator.cpp
+++ b/openjdk/mmtkMutator.cpp
@@ -2,6 +2,8 @@
 #include "mmtk.h"
 #include "mmtkMutator.hpp"
 
+size_t MMTkMutatorContext::max_non_los_default_alloc_bytes = 0;
+
 MMTkMutatorContext MMTkMutatorContext::bind(::Thread* current) {
     return *((MMTkMutatorContext*) ::bind_mutator((void*) current));
 }
@@ -9,7 +11,8 @@ MMTkMutatorContext MMTkMutatorContext::bind(::Thread* current) {
 HeapWord* MMTkMutatorContext::alloc(size_t bytes, Allocator allocator) {
     // All allocations with size larger than max non-los bytes will get to this slowpath here.
     // We will use LOS for those.
-    if (bytes >= get_max_non_los_default_alloc_bytes()) {
+    assert(MMTkMutatorContext::max_non_los_default_alloc_bytes != 0, "max_non_los_default_alloc_bytes hasn't been initialized");
+    if (bytes >= MMTkMutatorContext::max_non_los_default_alloc_bytes) {
         allocator = AllocatorLos;
     }
 

--- a/openjdk/mmtkMutator.cpp
+++ b/openjdk/mmtkMutator.cpp
@@ -8,18 +8,11 @@ MMTkMutatorContext MMTkMutatorContext::bind(::Thread* current) {
 }
 
 HeapWord* MMTkMutatorContext::alloc(size_t bytes, Allocator allocator) {
-    static std::atomic<long> slow_count(0);
-    static std::atomic<long> large_count(0);
-
-    slow_count.fetch_add(1);
+    // All allocations with size larger than max non-los bytes will get to this slowpath here.
+    // We will use LOS for those.
     if (bytes >= get_max_non_los_default_alloc_bytes()) {
         allocator = AllocatorLos;
-        large_count.fetch_add(1);
     }
-
-    // if (slow_count > 0 && slow_count % 10000 == 0) {
-    //     printf("slowpath alloc: %ld large / %ld total\n", large_count.load(), slow_count.load());
-    // }
 
     // FIXME: Proper use of slow-path api
     HeapWord* o = (HeapWord*) ::alloc((MMTk_Mutator) this, bytes, HeapWordSize, 0, allocator);

--- a/openjdk/mmtkMutator.cpp
+++ b/openjdk/mmtkMutator.cpp
@@ -17,9 +17,9 @@ HeapWord* MMTkMutatorContext::alloc(size_t bytes, Allocator allocator) {
         large_count.fetch_add(1);
     }
 
-    if (slow_count > 0 && slow_count % 10000 == 0) {
-        printf("slowpath alloc: %ld large / %ld total\n", large_count.load(), slow_count.load());
-    }
+    // if (slow_count > 0 && slow_count % 10000 == 0) {
+    //     printf("slowpath alloc: %ld large / %ld total\n", large_count.load(), slow_count.load());
+    // }
 
     // FIXME: Proper use of slow-path api
     HeapWord* o = (HeapWord*) ::alloc((MMTk_Mutator) this, bytes, HeapWordSize, 0, allocator);

--- a/openjdk/mmtkMutator.cpp
+++ b/openjdk/mmtkMutator.cpp
@@ -1,7 +1,6 @@
 
 #include "mmtk.h"
 #include "mmtkMutator.hpp"
-#include <atomic>
 
 MMTkMutatorContext MMTkMutatorContext::bind(::Thread* current) {
     return *((MMTkMutatorContext*) ::bind_mutator((void*) current));

--- a/openjdk/mmtkMutator.cpp
+++ b/openjdk/mmtkMutator.cpp
@@ -7,6 +7,10 @@ MMTkMutatorContext MMTkMutatorContext::bind(::Thread* current) {
 }
 
 HeapWord* MMTkMutatorContext::alloc(size_t bytes, Allocator allocator) {
+    if (bytes >= get_max_non_los_default_alloc_bytes()) {
+        allocator = AllocatorLos;
+    }
+
     // FIXME: Proper use of slow-path api
     HeapWord* o = (HeapWord*) ::alloc((MMTk_Mutator) this, bytes, HeapWordSize, 0, allocator);
     // Post allococation. Currently we are only calling post_alloc in slowpath here.

--- a/openjdk/mmtkMutator.hpp
+++ b/openjdk/mmtkMutator.hpp
@@ -70,6 +70,9 @@ struct MMTkMutatorContext {
     void flush();
 
     static MMTkMutatorContext bind(::Thread* current);
+
+    // Max object size that does not need to go into LOS. We get the value from mmtk-core, and cache its value here.
+    static size_t max_non_los_default_alloc_bytes;
 };
 
 #endif


### PR DESCRIPTION
This PR adds size check so we can allocate large objects directly to large object space.
* Adds a size check in the slowpath
* Adds a size check in the fastpath to jump to the slowpath