### PR TITLE
Remove hardcoded base address for VM global side metadata

### DIFF
--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -12,7 +12,7 @@ extern crate lazy_static;
 
 use std::ptr::null_mut;
 
-use libc::{c_char, c_void};
+use libc::{c_char, c_void, uintptr_t};
 use mmtk::scheduler::GCWorker;
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::{Address, ObjectReference};
@@ -84,6 +84,10 @@ pub struct OpenJDK_Upcalls {
 }
 
 pub static mut UPCALLS: *const OpenJDK_Upcalls = null_mut();
+
+#[no_mangle]
+pub static GLOBAL_SIDE_METADATA_VM_BASE_ADDRESS: uintptr_t =
+    crate::mmtk::util::metadata::side_metadata::GLOBAL_SIDE_METADATA_VM_BASE_ADDRESS.as_usize();
 
 #[derive(Default)]
 pub struct OpenJDK;

--- a/openjdk/barriers/mmtkObjectBarrier.hpp
+++ b/openjdk/barriers/mmtkObjectBarrier.hpp
@@ -6,6 +6,7 @@
 #include "c1/c1_LIRAssembler.hpp"
 #include "c1/c1_MacroAssembler.hpp"
 #include "gc/shared/barrierSet.hpp"
+#include "../mmtk.h"
 #include "../mmtkBarrierSet.hpp"
 #include "../mmtkBarrierSetAssembler_x86.hpp"
 #include "../mmtkBarrierSetC1.hpp"
@@ -13,10 +14,11 @@
 
 #define MMTK_ENABLE_OBJECT_BARRIER_FASTPATH true
 
-#define SIDE_METADATA_BASE_ADDRESS 0x0000060000000000L
 #define SIDE_METADATA_WORST_CASE_RATIO_LOG 1
 #define LOG_BYTES_IN_CHUNK 22
 #define CHUNK_MASK ((1L << LOG_BYTES_IN_CHUNK) - 1)
+
+const intptr_t SIDE_METADATA_BASE_ADDRESS = (intptr_t) GLOBAL_SIDE_METADATA_VM_BASE_ADDRESS;
 
 class MMTkObjectBarrierSetRuntime: public MMTkBarrierSetRuntime {
 public:

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -12,6 +12,8 @@ extern "C" {
 typedef void* MMTk_Mutator;
 typedef void* MMTk_TraceLocal;
 
+extern const uintptr_t GLOBAL_SIDE_METADATA_VM_BASE_ADDRESS;
+
 /**
  * Allocation
  */


### PR DESCRIPTION
Related to https://github.com/mmtk/mmtk-core/pull/361. The VM base address was a hardcoded macro before. Now it directly uses the MMTk core defined constant and so we do not have to mess around with change the constant whenever we update it.