### PR TITLE
Add feature to switch location of mark bit

### DIFF
--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -84,6 +84,28 @@ build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHea
 build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar hsqldb
 build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar eclipse
 
+# Run benchmarks with the mark bit in the header now
+unset MMTK_PLAN
+MARK_IN_HEADER=1 make CONF=linux-x86_64-normal-server-$DEBUG_LEVEL THIRD_PARTY_HEAP=$PWD/../../openjdk
+
+export MMTK_PLAN=MarkSweep
+
+# Test - the benchmarks that are commented out do not work yet
+# Note: the command line options are necessary for now to ensure the benchmarks work. We may later change the options if we do not have these many constraints.
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar antlr
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar bloat - does not work for stock build
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar fop
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar jython - does not work for stock build
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar luindex
+# build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar lusearch
+#- validation failed
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar pmd
+#build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar xalan - mmtk-core gets stuck in slowdebug build
+
+# These benchmarks take 40s+ for slowdebug build, we may consider removing them from the CI
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar hsqldb
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar eclipse
+
 # --- PageProtect ---
 # Make sure this runs last in our tests unless we want to set it back to the default limit.
 sudo sysctl -w vm.max_map_count=655300

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ $ make CONF=linux-x86_64-normal-server-$DEBUG_LEVEL THIRD_PARTY_HEAP=$PWD/../../
 
 The output jdk is at `./build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk`.
 
+### Location of Mark-bit
+The location of the mark-bit can be specified by the environment variable
+`MARK_IN_HEADER`. By default, the mark-bit is located on the side (in a side
+metadata), but by setting the environment variable `MARK_IN_HEADER=1` while
+building OpenJDK, we can change its location to be in the object's header:
+
+```console
+$ MARK_IN_HEADER=1 make CONF=linux-x86_64-normal-server-$DEBUG_LEVEL THIRD_PARTY_HEAP=$PWD/../../openjdk
+```
+
 ## Test
 
 ### Run HelloWorld (without MMTk)

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/k-sareen/mmtk-core.git", rev = "a5047d5e69ca3e89f3511b2d1845523ceadd22ff" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "f1b3ce4cf67149f724430406eea49f7a3b4c7fb2" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,6 +29,9 @@ default = []
 nogc_lock_free = ["mmtk/nogc_lock_free"]
 nogc_no_zeroing = ["mmtk/nogc_no_zeroing"]
 
+# This compile time constant places the mark bit in the header of the object instead of on the side.
+mark_bit_in_header = []
+
 # We can select plan at runtime. So no need to use any of these features.
 # However, if any of these is provided during build-time, we will ignore any runtime flag and
 # always run this plan. Performance-wise there is no difference. The main reason for these features

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "1e7964656eb0988e3fa4f216c5f8dfb1dba7b31f" }
+mmtk = { git = "https://github.com/k-sareen/mmtk-core.git", rev = "a5047d5e69ca3e89f3511b2d1845523ceadd22ff" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/vm_metadata/constants.rs
+++ b/mmtk/src/vm_metadata/constants.rs
@@ -33,8 +33,13 @@ pub(crate) const FORWARDING_BITS_METADATA_SPEC: VMLocalForwardingBitsSpec =
 
 /// PolicySpecific mark bit metadata spec
 /// 1 bit per object
+#[cfg(feature = "mark_bit_in_header")]
 pub(crate) const MARKING_METADATA_SPEC: VMLocalMarkBitSpec =
     VMLocalMarkBitSpec::in_header(FORWARDING_BITS_OFFSET);
+
+#[cfg(not(feature = "mark_bit_in_header"))]
+pub(crate) const MARKING_METADATA_SPEC: VMLocalMarkBitSpec =
+    VMLocalMarkBitSpec::side(LOS_METADATA_SPEC.offset());
 
 /// PolicySpecific mark-and-nursery bits metadata spec
 /// 2-bits per object

--- a/openjdk/CompileThirdPartyHeap.gmk
+++ b/openjdk/CompileThirdPartyHeap.gmk
@@ -3,11 +3,15 @@ MMTK_RUST_ROOT = $(TOPDIR)/../../mmtk
 MMTK_CPP_ROOT = $(TOPDIR)/../../openjdk
 
 ifdef MMTK_PLAN
-  GC_FEATURES_TMP="$(MMTK_PLAN)"
+  GC_FEATURES=--features $(MMTK_PLAN)
 endif
 
 ifeq ($(MARK_IN_HEADER), 1)
-  GC_FEATURES_TMP+=" mark_bit_in_header"
+  ifndef GC_FEATURES
+    GC_FEATURES=--features mark_bit_in_header
+  else
+    GC_FEATURES:=$(strip $(GC_FEATURES))",mark_bit_in_header"
+  endif
 endif
 
 LIB_MMTK := $(JVM_LIB_OUTPUTDIR)/libmmtk_openjdk.so
@@ -25,18 +29,13 @@ else
   CARGO_VERSION=+$(RUSTUP_TOOLCHAIN)
 endif
 
-$(LIB_MMTK): FORCE | GC_FEATURES_LIST
+$(LIB_MMTK): FORCE
+	echo "cargo $(CARGO_VERSION) build --manifest-path=$(MMTK_RUST_ROOT)/Cargo.toml $(CARGO_PROFILE_FLAG) $(GC_FEATURES)"
 	cargo $(CARGO_VERSION) build --manifest-path=$(MMTK_RUST_ROOT)/Cargo.toml $(CARGO_PROFILE_FLAG) $(GC_FEATURES)
 	cp $(MMTK_RUST_ROOT)/target/$(CARGO_PROFILE)/libmmtk_openjdk.so $(LIB_MMTK)
 
 JVM_LIBS += -L$(JVM_LIB_OUTPUTDIR) -lmmtk_openjdk
 JVM_LDFLAGS += '-Wl,-rpath,$$ORIGIN'
-
-GC_FEATURES_LIST:
-ifdef GC_FEATURES_TMP
-	GC_FEATURES="--features "; \
-	$(foreach x,$(GC_FEATURES_TMP),GC_FEATURES+=",$(x)";)
-endif
 
 FORCE:
 

--- a/openjdk/CompileThirdPartyHeap.gmk
+++ b/openjdk/CompileThirdPartyHeap.gmk
@@ -3,7 +3,11 @@ MMTK_RUST_ROOT = $(TOPDIR)/../../mmtk
 MMTK_CPP_ROOT = $(TOPDIR)/../../openjdk
 
 ifdef MMTK_PLAN
-  GC_FEATURES=--features $(MMTK_PLAN)
+  GC_FEATURES_TMP="$(MMTK_PLAN)"
+endif
+
+ifeq ($(MARK_IN_HEADER), 1)
+  GC_FEATURES_TMP+=" mark_bit_in_header"
 endif
 
 LIB_MMTK := $(JVM_LIB_OUTPUTDIR)/libmmtk_openjdk.so
@@ -21,12 +25,18 @@ else
   CARGO_VERSION=+$(RUSTUP_TOOLCHAIN)
 endif
 
-$(LIB_MMTK): FORCE
+$(LIB_MMTK): FORCE | GC_FEATURES_LIST
 	cargo $(CARGO_VERSION) build --manifest-path=$(MMTK_RUST_ROOT)/Cargo.toml $(CARGO_PROFILE_FLAG) $(GC_FEATURES)
 	cp $(MMTK_RUST_ROOT)/target/$(CARGO_PROFILE)/libmmtk_openjdk.so $(LIB_MMTK)
 
 JVM_LIBS += -L$(JVM_LIB_OUTPUTDIR) -lmmtk_openjdk
 JVM_LDFLAGS += '-Wl,-rpath,$$ORIGIN'
+
+GC_FEATURES_LIST:
+ifdef GC_FEATURES_TMP
+	GC_FEATURES="--features "; \
+	$(foreach x,$(GC_FEATURES_TMP),GC_FEATURES+=",$(x)";)
+endif
 
 FORCE:
 


### PR DESCRIPTION
This adds a feature `mark_bit_in_header` that switches the location of the mark bit. This feature requires https://github.com/mmtk/mmtk-core/pull/361 as it uses the newly defined `offset()` function.