### PR TITLE
Use `https://` git url for openjdk submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "repos/openjdk"]
 	path = repos/openjdk
-	url = git@github.com:mmtk/openjdk.git
+	url = https://github.com/mmtk/openjdk.git
 	branch = jdk-11.0.11+6-mmtk


### PR DESCRIPTION
In case people don't set up GitHub ssh keys properly.