### PR TITLE
Fix monitor use in finalizer thread.

### DIFF
--- a/openjdk/mmtkFinalizerThread.hpp
+++ b/openjdk/mmtkFinalizerThread.hpp
@@ -41,6 +41,7 @@ private:
     guarantee(false, "VMThread deletion must fix the race with VM termination");
   }
 public:
+  bool is_scheduled;
   Monitor* m;
   static MMTkFinalizerThread* instance;
   static void initialize();


### PR DESCRIPTION
-   Use a boolean variable to indicate if finalization is scheduled,
    instead of using the monitor alone.

-   Use ThreadBlockInVM instead of checking safepoint at monitor
    lock/wait.