### PR TITLE
Fix Issue 112

### DIFF
--- a/.github/scripts/ci-test-global-alloc-bit.sh
+++ b/.github/scripts/ci-test-global-alloc-bit.sh
@@ -19,46 +19,46 @@ make CONF=linux-x86_64-normal-server-$DEBUG_LEVEL THIRD_PARTY_HEAP=$PWD/../../op
 # --- SemiSpace ---
 export MMTK_PLAN=SemiSpace
 
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar antlr
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar fop
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar luindex
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar antlr
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar fop
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar luindex
 
 
 # --- Immix ---
 export MMTK_PLAN=Immix
 
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar antlr
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar fop
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar luindex
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar antlr
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar fop
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar luindex
 
 # --- GenImmix ---
 export MMTK_PLAN=GenImmix
 
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar antlr
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar fop
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar luindex
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar antlr
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar fop
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar luindex
 
 
 # --- GenCopy ---
 export MMTK_PLAN=GenCopy
 
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar antlr
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar fop
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar luindex
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar antlr
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar fop
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar luindex
 
 # --- NoGC ---
 
 export MMTK_PLAN=NoGC
 
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar antlr
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar fop
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar luindex
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar antlr
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar fop
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms1G -Xmx1G -jar benchmarks/dacapo-2006-10-MR2.jar luindex
 
 
 # --- MarkSweep ---
 export MMTK_PLAN=MarkSweep
 
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar antlr
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar fop
-build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -XX:-TieredCompilation -Xcomp -jar benchmarks/dacapo-2006-10-MR2.jar luindex
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar antlr
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar fop
+build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap -server -XX:MetaspaceSize=100M -Xms500M -Xmx500M -jar benchmarks/dacapo-2006-10-MR2.jar luindex
 

--- a/openjdk/mmtkBarrierSetAssembler_x86.cpp
+++ b/openjdk/mmtkBarrierSetAssembler_x86.cpp
@@ -112,12 +112,9 @@ void MMTkBarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register threa
     __ movptr(cursor, end);
 
 #ifdef MMTK_ENABLE_GLOBAL_ALLOC_BIT
-    Register tmp3 = rscratch2;
+    Register tmp3 = rdi;
     Register tmp2 = rscratch1;
     assert_different_registers(obj, tmp2, tmp3, rcx);
-
-    __ push(tmp2);
-    __ push(tmp3);
 
     // tmp2 = load-byte (SIDE_METADATA_BASE_ADDRESS + (obj >> 6));
     __ movptr(tmp3, obj);
@@ -141,8 +138,6 @@ void MMTkBarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register threa
     __ movptr(rcx, ALLOC_BIT_BASE_ADDRESS);
     __ movb(Address(rcx, tmp3), tmp2);  
 
-    __ pop(tmp3);
-    __ pop(tmp2);
 #endif
 
     // BarrierSetAssembler::incr_allocated_bytes

--- a/openjdk/mmtkBarrierSetAssembler_x86.cpp
+++ b/openjdk/mmtkBarrierSetAssembler_x86.cpp
@@ -114,8 +114,10 @@ void MMTkBarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register threa
 #ifdef MMTK_ENABLE_GLOBAL_ALLOC_BIT
     Register tmp3 = rscratch2;
     Register tmp2 = rscratch1;
-    Register tmp4 = t1;
-    assert_different_registers(obj, tmp2, tmp3, tmp4, rcx);
+    assert_different_registers(obj, tmp2, tmp3, rcx);
+
+    __ push(tmp2);
+    __ push(tmp3);
 
     // tmp2 = load-byte (SIDE_METADATA_BASE_ADDRESS + (obj >> 6));
     __ movptr(tmp3, obj);
@@ -123,24 +125,24 @@ void MMTkBarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register threa
     __ movptr(tmp2, ALLOC_BIT_BASE_ADDRESS);
     __ movb(tmp2, Address(tmp2, tmp3));
     // tmp3 = 1 << ((obj >> 3) & 7)
-    //   1. tmp4 = (obj >> 3) & 7
-    __ movptr(tmp4, obj);
-    __ shrptr(tmp4, 3);
-    __ andptr(tmp4, 7);
-    //   2. tmp4 = 1 << tmp4
-    __ movptr(tmp3, rcx);
-    __ movl(rcx, tmp4);
-    __ movptr(tmp4, 1);
-    __ shlptr(tmp4);
-    __ movptr(rcx, tmp3);
-    // tmp2 = tmp2 | tmp4
-    __ orptr(tmp2, tmp4);
+    //   1. rcx = (obj >> 3) & 7
+    __ movptr(rcx, obj);
+    __ shrptr(rcx, 3);
+    __ andptr(rcx, 7);
+    //   2. tmp3 = 1 << rcx
+    __ movptr(tmp3, 1);
+    __ shlptr(tmp3);
+    // tmp2 = tmp2 | tmp3
+    __ orptr(tmp2, tmp3);
 
     // store-byte tmp2 (SIDE_METADATA_BASE_ADDRESS + (obj >> 6))
     __ movptr(tmp3, obj);
     __ shrptr(tmp3, 6);
-    __ movptr(tmp4, ALLOC_BIT_BASE_ADDRESS);
-    __ movb(Address(tmp4, tmp3), tmp2);  
+    __ movptr(rcx, ALLOC_BIT_BASE_ADDRESS);
+    __ movb(Address(rcx, tmp3), tmp2);  
+
+    __ pop(tmp3);
+    __ pop(tmp2);
 #endif
 
     // BarrierSetAssembler::incr_allocated_bytes


### PR DESCRIPTION
fix #112

change the command line arguments in ci-tests, so that they run in C1-C2 tiered compilation mode (by default).