### PR TITLE
fix Interpreter allocation fastpath

### DIFF
--- a/openjdk/mmtkHeap.hpp
+++ b/openjdk/mmtkHeap.hpp
@@ -25,6 +25,7 @@
 #ifndef MMTK_OPENJDK_MMTK_HEAP_HPP
 #define MMTK_OPENJDK_MMTK_HEAP_HPP
 
+#include "mmtkBarrierSet.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/collectorPolicy.hpp"
 #include "gc/shared/gcPolicyCounters.hpp"
@@ -93,6 +94,10 @@ public:
   bool is_in(const void* p) const;
   bool is_in_reserved(const void* p) const;
   bool supports_tlab_allocation() const;
+
+  bool supports_inline_contig_alloc() const {
+    return MMTK_ENABLE_ALLOCATION_FASTPATH;
+  }
 
   // The amount of space available for thread-local allocation buffers.
   size_t tlab_capacity(Thread *thr) const;


### PR DESCRIPTION
https://github.com/mmtk/openjdk/blob/e1e420b3c4fd627218e45ec977972561c559acec/src/hotspot/cpu/x86/templateTable_x86.cpp#L4044

We need `supports_inline_contig_alloc()` to return `true` to initialize the object after calling our fastpath allocation, otherwise it will call the slowpath.

About `supports_inline_contig_alloc()`:
  // Some heaps may offer a contiguous region for shared non-blocking
  // allocation, via inlined code (by exporting the address of the top and
  // end fields defining the extent of the contiguous allocation region.)

  // This function returns "true" iff the heap supports this kind of
  // allocation.  (Default is "no".)
https://github.com/mmtk/openjdk/blob/e1e420b3c4fd627218e45ec977972561c559acec/src/hotspot/share/gc/shared/collectedHeap.hpp#L292

