### PR TITLE
Fix root scanning

### DIFF
--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -274,3 +274,22 @@ pub extern "C" fn get_finalized_object() -> ObjectReference {
         None => unsafe { Address::ZERO.to_object_reference() },
     }
 }
+
+/// Test if an object is live at the end of a GC.
+/// Note: only call this method after the liveness tracing and before gc release.
+#[no_mangle]
+pub extern "C" fn mmtk_is_live(object: ObjectReference) -> usize {
+    if object.is_null() {
+        return 0;
+    }
+    object.is_live() as _
+}
+
+/// If the object is non-null and forwarded, return the forwarded pointer. Otherwise, return the original pointer.
+#[no_mangle]
+pub extern "C" fn mmtk_get_forwarded_ref(object: ObjectReference) -> ObjectReference {
+    if object.is_null() {
+        return object;
+    }
+    object.get_forwarded_object().unwrap_or(object)
+}

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -1,4 +1,4 @@
-use mmtk::scheduler::WorkBucketStage;
+use mmtk::scheduler::{WorkBucketStage, GCWorker};
 use mmtk::scheduler::{ProcessEdgesWork, ScanStackRoot};
 use mmtk::util::alloc::AllocationError;
 use mmtk::util::opaque_pointer::*;
@@ -85,6 +85,12 @@ impl Collection<OpenJDK> for VMCollection {
     fn schedule_finalization(_tls: VMWorkerThread) {
         unsafe {
             ((*UPCALLS).schedule_finalizer)();
+        }
+    }
+
+    fn process_weak_refs<E: ProcessEdgesWork<VM = OpenJDK>>(_worker: &mut GCWorker<OpenJDK>) {
+        unsafe {
+            ((*UPCALLS).process_weak_refs)();
         }
     }
 }

--- a/mmtk/src/gc_work.rs
+++ b/mmtk/src/gc_work.rs
@@ -116,38 +116,6 @@ impl<E: ProcessEdgesWork<VM = OpenJDK>> GCWork<OpenJDK> for ScanSystemDictionary
     }
 }
 
-pub struct ScanCodeCacheRoots<E: ProcessEdgesWork<VM = OpenJDK>>(PhantomData<E>);
-
-impl<E: ProcessEdgesWork<VM = OpenJDK>> ScanCodeCacheRoots<E> {
-    pub fn new() -> Self {
-        Self(PhantomData)
-    }
-}
-
-impl<E: ProcessEdgesWork<VM = OpenJDK>> GCWork<OpenJDK> for ScanCodeCacheRoots<E> {
-    fn do_work(&mut self, _worker: &mut GCWorker<OpenJDK>, _mmtk: &'static MMTK<OpenJDK>) {
-        unsafe {
-            ((*UPCALLS).scan_code_cache_roots)(create_process_edges_work::<E> as _);
-        }
-    }
-}
-
-pub struct ScanStringTableRoots<E: ProcessEdgesWork<VM = OpenJDK>>(PhantomData<E>);
-
-impl<E: ProcessEdgesWork<VM = OpenJDK>> ScanStringTableRoots<E> {
-    pub fn new() -> Self {
-        Self(PhantomData)
-    }
-}
-
-impl<E: ProcessEdgesWork<VM = OpenJDK>> GCWork<OpenJDK> for ScanStringTableRoots<E> {
-    fn do_work(&mut self, _worker: &mut GCWorker<OpenJDK>, _mmtk: &'static MMTK<OpenJDK>) {
-        unsafe {
-            ((*UPCALLS).scan_string_table_roots)(create_process_edges_work::<E> as _);
-        }
-    }
-}
-
 pub struct ScanClassLoaderDataGraphRoots<E: ProcessEdgesWork<VM = OpenJDK>>(PhantomData<E>);
 
 impl<E: ProcessEdgesWork<VM = OpenJDK>> ScanClassLoaderDataGraphRoots<E> {
@@ -160,22 +128,6 @@ impl<E: ProcessEdgesWork<VM = OpenJDK>> GCWork<OpenJDK> for ScanClassLoaderDataG
     fn do_work(&mut self, _worker: &mut GCWorker<OpenJDK>, _mmtk: &'static MMTK<OpenJDK>) {
         unsafe {
             ((*UPCALLS).scan_class_loader_data_graph_roots)(create_process_edges_work::<E> as _);
-        }
-    }
-}
-
-pub struct ScanWeakProcessorRoots<E: ProcessEdgesWork<VM = OpenJDK>>(PhantomData<E>);
-
-impl<E: ProcessEdgesWork<VM = OpenJDK>> ScanWeakProcessorRoots<E> {
-    pub fn new() -> Self {
-        Self(PhantomData)
-    }
-}
-
-impl<E: ProcessEdgesWork<VM = OpenJDK>> GCWork<OpenJDK> for ScanWeakProcessorRoots<E> {
-    fn do_work(&mut self, _worker: &mut GCWorker<OpenJDK>, _mmtk: &'static MMTK<OpenJDK>) {
-        unsafe {
-            ((*UPCALLS).scan_weak_processor_roots)(create_process_edges_work::<E> as _);
         }
     }
 }

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -75,15 +75,13 @@ pub struct OpenJDK_Upcalls {
     pub scan_jvmti_export_roots: extern "C" fn(process_edges: ProcessEdgesFn),
     pub scan_aot_loader_roots: extern "C" fn(process_edges: ProcessEdgesFn),
     pub scan_system_dictionary_roots: extern "C" fn(process_edges: ProcessEdgesFn),
-    pub scan_code_cache_roots: extern "C" fn(process_edges: ProcessEdgesFn),
-    pub scan_string_table_roots: extern "C" fn(process_edges: ProcessEdgesFn),
     pub scan_class_loader_data_graph_roots: extern "C" fn(process_edges: ProcessEdgesFn),
-    pub scan_weak_processor_roots: extern "C" fn(process_edges: ProcessEdgesFn),
     pub scan_vm_thread_roots: extern "C" fn(process_edges: ProcessEdgesFn),
     pub number_of_mutators: extern "C" fn() -> usize,
     pub schedule_finalizer: extern "C" fn(),
     pub prepare_for_roots_re_scanning: extern "C" fn(),
     pub object_alignment: extern "C" fn() -> i32,
+    pub process_weak_refs: extern "C" fn(),
 }
 
 pub static mut UPCALLS: *const OpenJDK_Upcalls = null_mut();

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -83,10 +83,7 @@ impl Scanning<OpenJDK> for VMScanning {
                 box ScanJvmtiExportRoots::<W>::new(),
                 box ScanAOTLoaderRoots::<W>::new(),
                 box ScanSystemDictionaryRoots::<W>::new(),
-                box ScanCodeCacheRoots::<W>::new(),
-                box ScanStringTableRoots::<W>::new(),
                 box ScanClassLoaderDataGraphRoots::<W>::new(),
-                box ScanWeakProcessorRoots::<W>::new(),
             ],
         );
         if !(Self::SCAN_MUTATORS_IN_SAFEPOINT && Self::SINGLE_THREAD_MUTATOR_SCANNING) {

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -87,6 +87,9 @@ extern void handle_user_collection_request(void *tls);
 extern void start_control_collector(void *tls, void *context);
 extern void start_worker(void *tls, void* worker);
 
+extern size_t mmtk_is_live(void* object);
+extern void* mmtk_get_forwarded_ref(void* object);
+
 /**
  * VM Accounting
  */
@@ -136,14 +139,13 @@ typedef struct {
     void (*scan_jvmti_export_roots) (ProcessEdgesFn process_edges);
     void (*scan_aot_loader_roots) (ProcessEdgesFn process_edges);
     void (*scan_system_dictionary_roots) (ProcessEdgesFn process_edges);
-    void (*scan_code_cache_roots) (ProcessEdgesFn process_edges);
-    void (*scan_string_table_roots) (ProcessEdgesFn process_edges);
     void (*scan_class_loader_data_graph_roots) (ProcessEdgesFn process_edges);
-    void (*scan_weak_processor_roots) (ProcessEdgesFn process_edges);
     void (*scan_vm_thread_roots) (ProcessEdgesFn process_edges);
     size_t (*number_of_mutators)();
     void (*schedule_finalizer)();
     void (*prepare_for_roots_re_scanning)();
+    int32_t (*object_alignment)();
+    void (*process_weak_ref)();
 } OpenJDK_Upcalls;
 
 extern void openjdk_gc_init(OpenJDK_Upcalls *calls, size_t heap_size);

--- a/openjdk/mmtkHeap.hpp
+++ b/openjdk/mmtkHeap.hpp
@@ -156,6 +156,8 @@ public:
 
   void prepare_for_verify() ;
 
+  virtual void register_nmethod(nmethod* nm);
+  virtual void verify_nmethod(nmethod* nm);
 
 private:
 


### PR DESCRIPTION
This PR fixes memory leaks caused by incorrect root scanning.

Pointers in `CodeCache`, `StringTable` and `WeakProcessor` are not treated as roots. The processing of these object storage is postponed to the end of tracing. Pointers in these object storages are either removed (if they are dead) or forwarded (if they're moved).