### PR TITLE
Remove object_alignment upcall from OpenJDK_Upcalls.

### DIFF
--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -83,7 +83,6 @@ pub struct OpenJDK_Upcalls {
     pub number_of_mutators: extern "C" fn() -> usize,
     pub schedule_finalizer: extern "C" fn(),
     pub prepare_for_roots_re_scanning: extern "C" fn(),
-    pub object_alignment: extern "C" fn() -> i32,
 }
 
 pub static mut UPCALLS: *const OpenJDK_Upcalls = null_mut();


### PR DESCRIPTION
This fixes a mistake from https://github.com/mmtk/mmtk-openjdk/pull/124. The PR initially introduced `object_alignment()` as an upcall, but the call `object_alignment()` was removed during the code review. It seems the occurrence in the Rust type `OpenJDK_Upcalls` did not get removed, and the `OpenJDK_Upcalls` type [in Rust](https://github.com/mmtk/mmtk-openjdk/blob/18d35d8b9f3461620161cbe5f83b863ec245a70d/mmtk/src/lib.rs#L86) and [in C](https://github.com/mmtk/mmtk-openjdk/blob/18d35d8b9f3461620161cbe5f83b863ec245a70d/openjdk/mmtk.h#L147) does not match.

We are not seeing any issue caused by this bug, as this is the last field in the type, and it is never used. However, if we add new upcalls, we will see segfault when calling the new upcall.