### PR TITLE
Implement get_reference_when_copied_to

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "dbd152b29ff54c3f028318e73ac182d681deda9a" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", branch = "mark-compact-object-ref" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", branch = "mark-compact-object-ref" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "2d8dedcb42acfb6d70f20add143a8139581bec7c" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -119,8 +119,8 @@ impl ObjectModel<OpenJDK> for VMObjectModel {
         start + bytes
     }
 
-    fn get_reference_when_copied_to(_from: ObjectReference, _to: Address) -> ObjectReference {
-        unimplemented!()
+    fn get_reference_when_copied_to(_from: ObjectReference, to: Address) -> ObjectReference {
+        unsafe { to.to_object_reference() }
     }
 
     fn get_current_size(object: ObjectReference) -> usize {


### PR DESCRIPTION
This PR provides an implementation for `ObjectModel::get_reference_when_copied_to()`.