### PR TITLE
Replace TransitiveClosure with EdgeVisitor

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -26,9 +26,10 @@ lazy_static = "1.1"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "cd6d8984c10c294c991dcd5f154ce41073c06ab9" }
+#mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "cd6d8984c10c294c991dcd5f154ce41073c06ab9" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
+mmtk = { git = "https://github.com/wks/mmtk-core.git", branch = "scanning-no-transitive-closure" }
 
 [features]
 default = []

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -6,9 +6,9 @@ use mmtk::scheduler::ProcessEdgesWork;
 use mmtk::scheduler::{GCWorker, WorkBucketStage};
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::{Address, ObjectReference};
-use mmtk::vm::Scanning;
+use mmtk::vm::{EdgeVisitor, Scanning};
+use mmtk::Mutator;
 use mmtk::MutatorContext;
-use mmtk::{Mutator, TransitiveClosure};
 
 pub struct VMScanning {}
 
@@ -33,12 +33,12 @@ impl Scanning<OpenJDK> for VMScanning {
     const SCAN_MUTATORS_IN_SAFEPOINT: bool = false;
     const SINGLE_THREAD_MUTATOR_SCANNING: bool = false;
 
-    fn scan_object<T: TransitiveClosure>(
-        trace: &mut T,
+    fn scan_object<EV: EdgeVisitor>(
+        edge_visitor: &mut EV,
         object: ObjectReference,
         tls: VMWorkerThread,
     ) {
-        crate::object_scanning::scan_object(object, trace, tls)
+        crate::object_scanning::scan_object(object, edge_visitor, tls)
     }
 
     fn notify_initial_thread_scan_complete(_partial_scan: bool, _tls: VMWorkerThread) {


### PR DESCRIPTION
In respond to an upstream API change, we now use EdgeVisitor for object
scanning.  This also removes `unreachable!()` implementations for
`process_node()`.

This is associated with the PR in mmtk-core: https://github.com/mmtk/mmtk-core/pull/566