### PR TITLE
Update allocator struct layouts for stress test

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.10.0"
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
 mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "cacded40b7622e97dea56a83179aaa6af42920d0" }
 # Uncomment the following to build locally
-# mmtk = { path = "../repos/mmtk-core" }
+# mmtk = { path = "../../mmtk-core" }
 
 [features]
 default = []

--- a/openjdk/mmtkMutator.hpp
+++ b/openjdk/mmtkMutator.hpp
@@ -33,12 +33,14 @@ struct BumpAllocator {
   void* limit;
   RustDynPtr space;
   RustDynPtr plan;
+  uint8_t is_in_stress_test_alloc;
 };
 
 struct LargeObjectAllocator {
   void* tls;
   void* space;
   RustDynPtr plan;
+  uint8_t is_in_stress_test_alloc;
 };
 
 struct ImmixAllocator {
@@ -56,12 +58,14 @@ struct ImmixAllocator {
   uint8_t line_opt_tag;
   uintptr_t line_opt;
   uint8_t alloc_slow_for_stress;
+  uint8_t is_in_stress_test_alloc;
 };
 
 struct MallocAllocator {
   void* tls;
   void* space;
   RustDynPtr plan;
+  uint8_t is_in_stress_test_alloc;
 };
 
 struct MarkCompactAllocator {


### PR DESCRIPTION
Adds extra boolean to the allocator structs in order to match the layout in https://github.com/mmtk/mmtk-core/pull/568. I've also updated the local mmtk path in the Cargo.toml file in order to reflect the fact that we don't have a `repos` folder anymore