### PR TITLE
Fix missing includes

### DIFF
--- a/openjdk/mmtkBarrierSetC2.cpp
+++ b/openjdk/mmtkBarrierSetC2.cpp
@@ -34,9 +34,12 @@
 #include "opto/graphKit.hpp"
 #include "opto/idealKit.hpp"
 #include "opto/macro.hpp"
+#include "opto/movenode.hpp"
 #include "opto/narrowptrnode.hpp"
 #include "opto/node.hpp"
+#include "opto/runtime.hpp"
 #include "opto/type.hpp"
+#include "runtime/sharedRuntime.hpp"
 #include "utilities/macros.hpp"
 
 void MMTkBarrierSetC2::expand_allocate(PhaseMacroExpand* x,

--- a/openjdk/mmtkFinalizerThread.cpp
+++ b/openjdk/mmtkFinalizerThread.cpp
@@ -24,8 +24,10 @@
 
 #include "precompiled.hpp"
 #include "classfile/stringTable.hpp"
+#include "classfile/symbolTable.hpp"
 #include "mmtk.h"
 #include "mmtkFinalizerThread.hpp"
+#include "oops/oop.inline.hpp"
 #include "prims/jvmtiImpl.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaCalls.hpp"

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -32,6 +32,7 @@
 #include "gc/shared/strongRootsScope.hpp"
 #include "gc/shared/weakProcessor.hpp"
 #include "logging/log.hpp"
+#include "memory/resourceArea.hpp"
 #include "mmtk.h"
 #include "mmtkHeap.hpp"
 #include "mmtkMutator.hpp"

--- a/openjdk/mmtkVMCompanionThread.cpp
+++ b/openjdk/mmtkVMCompanionThread.cpp
@@ -26,6 +26,7 @@
 #include "mmtk.h"
 #include "mmtkVMCompanionThread.hpp"
 #include "runtime/mutex.hpp"
+#include "logging/log.hpp"
 
 MMTkVMCompanionThread::MMTkVMCompanionThread():
     NamedThread(),

--- a/openjdk/mmtkVMOperation.cpp
+++ b/openjdk/mmtkVMOperation.cpp
@@ -26,6 +26,7 @@
 #include "mmtk.h"
 #include "mmtkVMCompanionThread.hpp"
 #include "mmtkVMOperation.hpp"
+#include "logging/log.hpp"
 
 VM_MMTkSTWOperation::VM_MMTkSTWOperation(MMTkVMCompanionThread *companion_thread):
     _companion_thread(companion_thread) {


### PR DESCRIPTION
This adds a few missing includes that I found necessary to build mmtk-openjdk.
Detected by building OpenJDK with --disable-precompiled-headers.