### PR TITLE
Fix MarkCompact C2 fastpath and refactor allocator offset calculation

### DIFF
--- a/openjdk/mmtkBarrierSet.hpp
+++ b/openjdk/mmtkBarrierSet.hpp
@@ -40,6 +40,20 @@
 
 const intptr_t ALLOC_BIT_BASE_ADDRESS = GLOBAL_ALLOC_BIT_ADDRESS;
 
+struct MMTkAllocatorOffsets {
+  int tlab_top_offset;
+  int tlab_end_offset;
+};
+
+/**
+ * Return the offset (from the start of the mutator) for the TLAB top (cursor)
+ * and end (limit) for an MMTk Allocator.
+ *
+ * @param selector The current MMTk Allocator being used
+ * @return the offsets to the top and end of the TLAB
+ */
+MMTkAllocatorOffsets get_tlab_top_and_end_offsets(AllocatorSelector selector);
+
 class MMTkBarrierSetRuntime: public CHeapObj<mtGC> {
 public:
   virtual void record_modified_node(oop object) {};

--- a/openjdk/mmtkBarrierSetC2.cpp
+++ b/openjdk/mmtkBarrierSetC2.cpp
@@ -177,39 +177,12 @@ void MMTkBarrierSetC2::expand_allocate(PhaseMacroExpand* x,
     Node* eden_end_adr;
 
     {
-      // Only bump pointer allocator fastpath is implemented.
-      if (selector.tag != TAG_BUMP_POINTER && selector.tag != TAG_MARK_COMPACT && selector.tag != TAG_IMMIX) {
-        fatal("unimplemented allocator fastpath\n");
-      }
+      // Calculate offsets of TLAB top and end
+      MMTkAllocatorOffsets alloc_offsets = get_tlab_top_and_end_offsets(selector);
 
-      // Calculat offsets of top and end. We now assume we are using bump pointer.
-      int allocators_base_offset = in_bytes(JavaThread::third_party_heap_mutator_offset())
-        + in_bytes(byte_offset_of(MMTkMutatorContext, allocators));
-      int tlab_top_offset, tlab_end_offset;
-      if (selector.tag == TAG_IMMIX) {
-        int allocator_base_offset = allocators_base_offset
-          + in_bytes(byte_offset_of(Allocators, immix))
-          + selector.index * sizeof(ImmixAllocator);
-        tlab_top_offset = allocator_base_offset + in_bytes(byte_offset_of(ImmixAllocator, cursor));
-        tlab_end_offset = allocator_base_offset + in_bytes(byte_offset_of(ImmixAllocator, limit));
-      } else if (selector.tag == TAG_BUMP_POINTER) {
-        int allocator_base_offset = allocators_base_offset
-          + in_bytes(byte_offset_of(Allocators, bump_pointer))
-          + selector.index * sizeof(BumpAllocator);
-        tlab_top_offset = allocator_base_offset + in_bytes(byte_offset_of(BumpAllocator, cursor));
-        tlab_end_offset = allocator_base_offset + in_bytes(byte_offset_of(BumpAllocator, limit));
-      } else {
-        // markcompact allocator
-        int allocator_base_offset = allocators_base_offset
-          + in_bytes(byte_offset_of(Allocators, bump_pointer))
-          + selector.index * sizeof(MarkCompactAllocator)
-          + in_bytes(byte_offset_of(MarkCompactAllocator, bump_allocator));
-        tlab_top_offset = allocator_base_offset + in_bytes(byte_offset_of(BumpAllocator, cursor));
-        tlab_end_offset = allocator_base_offset + in_bytes(byte_offset_of(BumpAllocator, limit));
-      }
       Node* thread = x->transform_later(new ThreadLocalNode());
-      eden_top_adr = x->basic_plus_adr(x->top()/*not oop*/, thread, tlab_top_offset);
-      eden_end_adr = x->basic_plus_adr(x->top()/*not oop*/, thread, tlab_end_offset);
+      eden_top_adr = x->basic_plus_adr(x->top()/*not oop*/, thread, alloc_offsets.tlab_top_offset);
+      eden_end_adr = x->basic_plus_adr(x->top()/*not oop*/, thread, alloc_offsets.tlab_end_offset);
     }
 
     // set_eden_pointers(eden_top_adr, eden_end_adr);
@@ -239,7 +212,7 @@ void MMTkBarrierSetC2::expand_allocate(PhaseMacroExpand* x,
 
     // Load(-locked) the heap top.
     // See note above concerning the control input when using a TLAB
-    Node *old_eden_top; 
+    Node *old_eden_top;
 
     if (selector.tag == TAG_MARK_COMPACT) {
       Node *offset = ConLNode::make(extra_header);
@@ -303,15 +276,14 @@ void MMTkBarrierSetC2::expand_allocate(PhaseMacroExpand* x,
     #ifdef MMTK_ENABLE_GLOBAL_ALLOC_BIT
     enable_global_alloc_bit = true;
     #endif
-// #ifdef MMTK_ENABLE_GLOBAL_ALLOC_BIT
-  if(enable_global_alloc_bit || selector.tag == TAG_MARK_COMPACT) {
-    // set the alloc bit:          
+  if (enable_global_alloc_bit || selector.tag == TAG_MARK_COMPACT) {
+    // set the alloc bit:
     // intptr_t addr = (intptr_t) (void*) fast_oop;
     // uint8_t* meta_addr = (uint8_t*) (ALLOC_BIT_BASE_ADDRESS + (addr >> 6));
     // intptr_t shift = (addr >> 3) & 0b111;
     // uint8_t byte_val = *meta_addr;
     // uint8_t new_byte_val = byte_val | (1 << shift);
-    // *meta_addr = new_byte_val;  
+    // *meta_addr = new_byte_val;
     Node *obj_addr = new CastP2XNode(fast_oop_ctrl, fast_oop);
     x->transform_later(obj_addr);
 
@@ -348,7 +320,7 @@ void MMTkBarrierSetC2::expand_allocate(PhaseMacroExpand* x,
     Node *const_one =  ConINode::make(1);
     x->transform_later(const_one);
 
-    Node *shifted_masked_addr_i = new ConvL2INode(shifted_masked_addr);   
+    Node *shifted_masked_addr_i = new ConvL2INode(shifted_masked_addr);
     x->transform_later(shifted_masked_addr_i);
 
     Node *set_bit = new LShiftINode(const_one, shifted_masked_addr_i);
@@ -362,7 +334,6 @@ void MMTkBarrierSetC2::expand_allocate(PhaseMacroExpand* x,
 
     fast_oop_rawmem = set_alloc_bit;
   }
-// #endif
 
     InitializeNode* init = alloc->initialization();
     fast_oop_rawmem = x->initialize_object(alloc,


### PR DESCRIPTION
MarkCompactAllocator mistakenly used the offset for `bump_allocator` in
the Allocators struct instead of the offset for `markcompact` in its C2
fastpath. This commit fixes the above issue and refactors the duplicated
offset calculation code in the C1 and C2 fastpaths into a new function.