### PR TITLE
Get build info from mmtk-core

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -51,6 +51,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "built"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f346b6890a0dfa7266974910e7df2d5088120dd54721b9b0e5aae1ae5e05715"
+dependencies = [
+ "cargo-lock",
+ "git2",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c408da54db4c50d4693f7e649c299bc9de9c23ead86249e5368830bb32a734b"
+dependencies = [
+ "semver 1.0.13",
+ "serde",
+ "toml",
+ "url",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +208,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "git2"
+version = "0.13.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +252,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,9 +279,33 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.12.26+1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -211,6 +315,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -230,11 +340,12 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=a96e8f991c91a81df51e7975849441f52fdbcdcc#a96e8f991c91a81df51e7975849441f52fdbcdcc"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=855207420c052de36bfd3e93f11f3fc2db4aeff8#855207420c052de36bfd3e93f11f3fc2db4aeff8"
 dependencies = [
  "atomic",
  "atomic-traits",
  "atomic_refcell",
+ "built",
  "crossbeam",
  "downcast-rs",
  "enum-map",
@@ -252,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=a96e8f991c91a81df51e7975849441f52fdbcdcc#a96e8f991c91a81df51e7975849441f52fdbcdcc"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=855207420c052de36bfd3e93f11f3fc2db4aeff8#855207420c052de36bfd3e93f11f3fc2db4aeff8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -285,6 +396,18 @@ name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "proc-macro-error"
@@ -351,7 +474,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -376,10 +499,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "spin"
@@ -427,10 +579,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=855207420c052de36bfd3e93f11f3fc2db4aeff8#855207420c052de36bfd3e93f11f3fc2db4aeff8"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=d63db9a908acde8ccf8dfde22d3e59affc74e5a8#d63db9a908acde8ccf8dfde22d3e59affc74e5a8"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=855207420c052de36bfd3e93f11f3fc2db4aeff8#855207420c052de36bfd3e93f11f3fc2db4aeff8"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=d63db9a908acde8ccf8dfde22d3e59affc74e5a8#d63db9a908acde8ccf8dfde22d3e59affc74e5a8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -375,6 +375,7 @@ dependencies = [
 name = "mmtk_openjdk"
 version = "0.14.0"
 dependencies = [
+ "built",
  "lazy_static",
  "libc",
  "mmtk",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -279,9 +279,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.129"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "libgit2-sys"
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2#6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=4904004d55c48858d12a97a8e2ebb559fb91c0de#4904004d55c48858d12a97a8e2ebb559fb91c0de"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2#6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=4904004d55c48858d12a97a8e2ebb559fb91c0de#4904004d55c48858d12a97a8e2ebb559fb91c0de"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=a48acac02f213529d23b4aebd81986cfea4495e4#a48acac02f213529d23b4aebd81986cfea4495e4"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2#6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=a48acac02f213529d23b4aebd81986cfea4495e4#a48acac02f213529d23b4aebd81986cfea4495e4"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2#6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=d63db9a908acde8ccf8dfde22d3e59affc74e5a8#d63db9a908acde8ccf8dfde22d3e59affc74e5a8"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=a48acac02f213529d23b4aebd81986cfea4495e4#a48acac02f213529d23b4aebd81986cfea4495e4"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=d63db9a908acde8ccf8dfde22d3e59affc74e5a8#d63db9a908acde8ccf8dfde22d3e59affc74e5a8"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=a48acac02f213529d23b4aebd81986cfea4495e4#a48acac02f213529d23b4aebd81986cfea4495e4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "mmtk_openjdk"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "built",
  "lazy_static",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -3,6 +3,7 @@ name = "mmtk_openjdk"
 version = "0.14.0"
 authors = [" <>"]
 rust-version = "1.57.0"
+build = "build.rs"
 
 [lib]
 name = "mmtk_openjdk"
@@ -28,9 +29,12 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "855207420c052de36bfd3e93f11f3fc2db4aeff8" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "d63db9a908acde8ccf8dfde22d3e59affc74e5a8" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
+
+[build-dependencies]
+built = { version = "0.5.1", features = ["git2"] }
 
 [features]
 default = []

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "d63db9a908acde8ccf8dfde22d3e59affc74e5a8" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "a48acac02f213529d23b4aebd81986cfea4495e4" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "a48acac02f213529d23b4aebd81986cfea4495e4" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -16,7 +16,7 @@ lto = true
 [package.metadata.openjdk]
 # Our CI matches the following line and extract mmtk/openjdk. If this line is updated, please check ci yaml files and make sure it works.
 openjdk_repo = "https://github.com/mmtk/openjdk.git"
-openjdk_version = "5180a3241b7477b056f4e5c61d1267f6f48aeab3"
+openjdk_version = "342847479ef5bae857053ea78d78729523234887"
 
 [dependencies]
 libc = "0.2"
@@ -28,7 +28,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "a96e8f991c91a81df51e7975849441f52fdbcdcc" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "855207420c052de36bfd3e93f11f3fc2db4aeff8" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -17,7 +17,7 @@ lto = true
 [package.metadata.openjdk]
 # Our CI matches the following line and extract mmtk/openjdk. If this line is updated, please check ci yaml files and make sure it works.
 openjdk_repo = "https://github.com/mmtk/openjdk.git"
-openjdk_version = "342847479ef5bae857053ea78d78729523234887"
+openjdk_version = "ad1809129d6288e7f8226990840e5d32aab0ea34"
 
 [dependencies]
 libc = "0.2"
@@ -29,7 +29,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "6a37d3ec16c65c9fadf3dd7a180f702a3d27c0e2" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "4904004d55c48858d12a97a8e2ebb559fb91c0de" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/build.rs
+++ b/mmtk/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -25,6 +25,11 @@ static OBJECT_BARRIER: sync::Lazy<CString> =
     sync::Lazy::new(|| CString::new("ObjectBarrier").unwrap());
 
 #[no_mangle]
+pub extern "C" fn get_mmtk_version() -> *const c_char {
+    mmtk::build_info::MMTK_FULL_BUILD_INFO.as_ptr() as _
+}
+
+#[no_mangle]
 pub extern "C" fn mmtk_active_barrier() -> *const c_char {
     match SINGLETON.get_plan().constraints().barrier {
         BarrierSelector::NoBarrier => NO_BARRIER.as_ptr(),

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -26,7 +26,7 @@ static OBJECT_BARRIER: sync::Lazy<CString> =
 
 #[no_mangle]
 pub extern "C" fn get_mmtk_version() -> *const c_char {
-    mmtk::build_info::MMTK_FULL_BUILD_INFO.as_ptr() as _
+    crate::build_info::MMTK_OPENJDK_FULL_VERSION.as_ptr() as _
 }
 
 #[no_mangle]

--- a/mmtk/src/build_info.rs
+++ b/mmtk/src/build_info.rs
@@ -7,8 +7,8 @@ lazy_static! {
     // Owned string for the binding version, such as MMTk OpenJDK 0.14.0 (cfc755f-dirty)
     static ref BINDING_VERSION_STRING: String = match (raw::GIT_COMMIT_HASH, raw::GIT_DIRTY) {
         (Some(hash), Some(dirty)) => format!("MMTk OpenJDK {} ({}{})", raw::PKG_VERSION, hash.split_at(7).0, if dirty { "-dirty" } else { "" }),
-        (None, None) => format!("MMTk OpenJDK {}", raw::PKG_VERSION),
-        x => unreachable!("Unexpected GIT_COMMIT_HASH and GIT_DIRTY {:?}", x)
+        (Some(hash), None) => format!("MMTk OpenJDK {} ({}{})", raw::PKG_VERSION, hash.split_at(7).0, "-?"),
+        _ => format!("MMTk OpenJDK {}", raw::PKG_VERSION),
     };
     // Owned string for both binding and core version.
     static ref MMTK_OPENJDK_FULL_VERSION_STRING: String = format!("{}, using {}", *BINDING_VERSION_STRING, *mmtk::build_info::MMTK_FULL_BUILD_INFO);

--- a/mmtk/src/build_info.rs
+++ b/mmtk/src/build_info.rs
@@ -1,0 +1,18 @@
+mod raw {
+    // The include imports a full list of the constants in built.rs from https://docs.rs/built/latest/built/index.html
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+lazy_static! {
+    // Owned string for the binding version, such as MMTk OpenJDK 0.14.0 (cfc755f-dirty)
+    static ref BINDING_VERSION_STRING: String = match (raw::GIT_COMMIT_HASH, raw::GIT_DIRTY) {
+        (Some(hash), Some(dirty)) => format!("MMTk OpenJDK {} ({}{})", raw::PKG_VERSION, hash.split_at(7).0, if dirty { "-dirty" } else { "" }),
+        (None, None) => format!("MMTk OpenJDK {}", raw::PKG_VERSION),
+        x => unreachable!("Unexpected GIT_COMMIT_HASH and GIT_DIRTY {:?}", x)
+    };
+    // Owned string for both binding and core version.
+    static ref MMTK_OPENJDK_FULL_VERSION_STRING: String = format!("{}, using {}", *BINDING_VERSION_STRING, *mmtk::build_info::MMTK_FULL_BUILD_INFO);
+
+    // Exposed &str for the full version.
+    pub static ref MMTK_OPENJDK_FULL_VERSION: &'static str = &MMTK_OPENJDK_FULL_VERSION_STRING;
+}

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -21,6 +21,7 @@ use mmtk::MMTK;
 mod abi;
 pub mod active_plan;
 pub mod api;
+mod build_info;
 pub mod collection;
 mod gc_work;
 pub mod object_model;

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -23,6 +23,8 @@ extern const uintptr_t GLOBAL_SIDE_METADATA_VM_BASE_ADDRESS;
 extern const uintptr_t GLOBAL_ALLOC_BIT_ADDRESS;
 extern const size_t MMTK_MARK_COMPACT_HEADER_RESERVED_IN_BYTES;
 
+extern const char* get_mmtk_version();
+
 /**
  * Allocation
  */

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -126,6 +126,10 @@ jint MMTkHeap::initialize() {
 
 }
 
+const char* MMTkHeap::version() {
+  return get_mmtk_version();
+}
+
 void MMTkHeap::schedule_finalizer() {
   MMTkFinalizerThread::instance->schedule();
 }

--- a/openjdk/mmtkHeap.hpp
+++ b/openjdk/mmtkHeap.hpp
@@ -88,6 +88,7 @@ public:
   const char* name() const {
     return "MMTk";
   }
+  static const char* version();
 
   size_t capacity() const;
   size_t used() const;


### PR DESCRIPTION
This PR implements `ThirdPartyHeap::version()` for https://github.com/mmtk/openjdk/pull/14.