### PR TITLE
Update to mmtk-core PR #644

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=20beba8438eb232cb6375d78c596e4051f3917fe#20beba8438eb232cb6375d78c596e4051f3917fe"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=d8bcf90991224cfe06153689b14c3e1eea0e025e#d8bcf90991224cfe06153689b14c3e1eea0e025e"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=20beba8438eb232cb6375d78c596e4051f3917fe#20beba8438eb232cb6375d78c596e4051f3917fe"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=d8bcf90991224cfe06153689b14c3e1eea0e025e#d8bcf90991224cfe06153689b14c3e1eea0e025e"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=e4eb3d2834c74f67b649c4d923c005e095487c1a#e4eb3d2834c74f67b649c4d923c005e095487c1a"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=dc2a4293d103ca814f5f9e526552b5ef08502240#dc2a4293d103ca814f5f9e526552b5ef08502240"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=e4eb3d2834c74f67b649c4d923c005e095487c1a#e4eb3d2834c74f67b649c4d923c005e095487c1a"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=dc2a4293d103ca814f5f9e526552b5ef08502240#dc2a4293d103ca814f5f9e526552b5ef08502240"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=4904004d55c48858d12a97a8e2ebb559fb91c0de#4904004d55c48858d12a97a8e2ebb559fb91c0de"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=e4eb3d2834c74f67b649c4d923c005e095487c1a#e4eb3d2834c74f67b649c4d923c005e095487c1a"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=4904004d55c48858d12a97a8e2ebb559fb91c0de#4904004d55c48858d12a97a8e2ebb559fb91c0de"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=e4eb3d2834c74f67b649c4d923c005e095487c1a#e4eb3d2834c74f67b649c4d923c005e095487c1a"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=dc2a4293d103ca814f5f9e526552b5ef08502240#dc2a4293d103ca814f5f9e526552b5ef08502240"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=20beba8438eb232cb6375d78c596e4051f3917fe#20beba8438eb232cb6375d78c596e4051f3917fe"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=dc2a4293d103ca814f5f9e526552b5ef08502240#dc2a4293d103ca814f5f9e526552b5ef08502240"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=20beba8438eb232cb6375d78c596e4051f3917fe#20beba8438eb232cb6375d78c596e4051f3917fe"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "20beba8438eb232cb6375d78c596e4051f3917fe" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "d8bcf90991224cfe06153689b14c3e1eea0e025e" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "4904004d55c48858d12a97a8e2ebb559fb91c0de" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "e4eb3d2834c74f67b649c4d923c005e095487c1a" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "e4eb3d2834c74f67b649c4d923c005e095487c1a" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "dc2a4293d103ca814f5f9e526552b5ef08502240" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "dc2a4293d103ca814f5f9e526552b5ef08502240" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "20beba8438eb232cb6375d78c596e4051f3917fe" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -309,11 +309,20 @@ pub extern "C" fn executable() -> bool {
 }
 
 #[no_mangle]
-pub extern "C" fn record_modified_node(
+pub extern "C" fn post_write_barrier(mutator: &'static mut Mutator<OpenJDK>, obj: ObjectReference) {
+    mutator
+        .barrier()
+        .post_write_barrier(mmtk::plan::BarrierWriteTarget::Object(obj))
+}
+
+#[no_mangle]
+pub extern "C" fn post_write_barrier_slow(
     mutator: &'static mut Mutator<OpenJDK>,
     obj: ObjectReference,
 ) {
-    mutator.record_modified_node(obj);
+    mutator
+        .barrier()
+        .post_write_barrier_slow(mmtk::plan::BarrierWriteTarget::Object(obj))
 }
 
 // finalization

--- a/openjdk/barriers/mmtkObjectBarrier.cpp
+++ b/openjdk/barriers/mmtkObjectBarrier.cpp
@@ -6,6 +6,10 @@ void MMTkObjectBarrierSetRuntime::record_modified_node_slow(void* obj) {
   ::post_write_barrier_slow((MMTk_Mutator) &Thread::current()->third_party_heap_mutator, (void*) obj);
 }
 
+void MMTkObjectBarrierSetRuntime::record_modified_node_full(void* obj) {
+  ::post_write_barrier((MMTk_Mutator) &Thread::current()->third_party_heap_mutator, (void*) obj);
+}
+
 void MMTkObjectBarrierSetRuntime::record_modified_node(oop src) {
 #if MMTK_ENABLE_OBJECT_BARRIER_FASTPATH
   intptr_t addr = (intptr_t) (void*) src;
@@ -16,7 +20,7 @@ void MMTkObjectBarrierSetRuntime::record_modified_node(oop src) {
     record_modified_node_slow((void*) src);
   }
 #else
-  ::post_write_barrier((MMTk_Mutator) &Thread::current()->third_party_heap_mutator, (void*) src);
+  record_modified_node_full((void*) src);
 #endif
 }
 
@@ -73,7 +77,7 @@ void MMTkObjectBarrierSetAssembler::record_modified_node(MacroAssembler* masm, R
 #else
   assert_different_registers(c_rarg0, obj);
   __ movptr(c_rarg0, obj);
-  __ call_VM_leaf_base(CAST_FROM_FN_PTR(address, MMTkObjectBarrierSetRuntime::record_modified_node_slow), 1);
+  __ call_VM_leaf_base(CAST_FROM_FN_PTR(address, MMTkObjectBarrierSetRuntime::record_modified_node_full), 1);
 #endif
 }
 
@@ -194,7 +198,7 @@ void MMTkObjectBarrierSetC2::record_modified_node(GraphKit* kit, Node* src, Node
   } __ end_if();
 #else
   const TypeFunc* tf = __ func_type(TypeOopPtr::BOTTOM);
-  Node* x = __ make_leaf_call(tf, CAST_FROM_FN_PTR(address, MMTkObjectBarrierSetRuntime::record_modified_node_slow), "record_modified_node", src);
+  Node* x = __ make_leaf_call(tf, CAST_FROM_FN_PTR(address, MMTkObjectBarrierSetRuntime::record_modified_node_full), "record_modified_node", src);
 #endif
 
   kit->final_sync(ideal); // Final sync IdealKit and GraphKit.

--- a/openjdk/barriers/mmtkObjectBarrier.cpp
+++ b/openjdk/barriers/mmtkObjectBarrier.cpp
@@ -3,7 +3,7 @@
 #include "runtime/interfaceSupport.inline.hpp"
 
 void MMTkObjectBarrierSetRuntime::record_modified_node_slow(void* obj) {
-  ::record_modified_node((MMTk_Mutator) &Thread::current()->third_party_heap_mutator, (void*) obj);
+  ::post_write_barrier_slow((MMTk_Mutator) &Thread::current()->third_party_heap_mutator, (void*) obj);
 }
 
 void MMTkObjectBarrierSetRuntime::record_modified_node(oop src) {
@@ -16,7 +16,7 @@ void MMTkObjectBarrierSetRuntime::record_modified_node(oop src) {
     record_modified_node_slow((void*) src);
   }
 #else
-  record_modified_node_slow((void*) src);
+  ::post_write_barrier((MMTk_Mutator) &Thread::current()->third_party_heap_mutator, (void*) src);
 #endif
 }
 

--- a/openjdk/barriers/mmtkObjectBarrier.hpp
+++ b/openjdk/barriers/mmtkObjectBarrier.hpp
@@ -23,9 +23,10 @@ const intptr_t SIDE_METADATA_BASE_ADDRESS = (intptr_t) GLOBAL_SIDE_METADATA_VM_B
 class MMTkObjectBarrierSetRuntime: public MMTkBarrierSetRuntime {
 public:
   static void record_modified_node_slow(void* src);
+  static void record_modified_node_full(void* src);
 
   virtual bool is_slow_path_call(address call) {
-    return call == CAST_FROM_FN_PTR(address, record_modified_node_slow);
+    return call == CAST_FROM_FN_PTR(address, record_modified_node_slow) || call == CAST_FROM_FN_PTR(address, record_modified_node_full);
   }
 
   virtual void record_modified_node(oop src);
@@ -68,7 +69,7 @@ public:
 
     __ save_live_registers_no_oop_map(true);
 
-    __ call_VM_leaf_base(CAST_FROM_FN_PTR(address, MMTkObjectBarrierSetRuntime::record_modified_node_slow), 1);
+    __ call_VM_leaf_base(CAST_FROM_FN_PTR(address, MMTkObjectBarrierSetRuntime::record_modified_node_full), 1);
 
     __ restore_live_registers(true);
 

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -45,7 +45,8 @@ extern void* alloc_slow_largeobject(MMTk_Mutator mutator, size_t size,
 extern void post_alloc(MMTk_Mutator mutator, void* refer,
     int bytes, int allocator);
 
-extern void record_modified_node(MMTk_Mutator mutator, void* obj);
+extern void post_write_barrier(MMTk_Mutator mutator, void* obj);
+extern void post_write_barrier_slow(MMTk_Mutator mutator, void* obj);
 
 extern void release_buffer(void** buffer, size_t len, size_t cap);
 


### PR DESCRIPTION
This PR updates the OpenJDK binding for https://github.com/mmtk/mmtk-core/pull/644. Furthermore, it separates a write barrier call from the write barrier slowpath call.