### PR TITLE
Fix function pointer type.

### DIFF
--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -8,11 +8,13 @@ use crate::{MutatorClosure, OpenJDK};
 
 pub struct VMCollection {}
 
-extern "C" fn report_mutator_stop<F>(mutator: *mut Mutator<OpenJDK>, callback: *mut F)
-where
+extern "C" fn report_mutator_stop<F>(
+    mutator: *mut Mutator<OpenJDK>,
+    callback_ptr: *mut libc::c_void,
+) where
     F: FnMut(&'static mut Mutator<OpenJDK>),
 {
-    let callback: &mut F = unsafe { &mut *callback };
+    let callback: &mut F = unsafe { &mut *(callback_ptr as *mut F) };
     callback(unsafe { &mut *mutator });
 }
 
@@ -21,7 +23,7 @@ where
     F: FnMut(&'static mut Mutator<OpenJDK>),
 {
     MutatorClosure {
-        func: report_mutator_stop::<F> as *const _,
+        func: report_mutator_stop::<F>,
         data: callback as *mut F as *mut libc::c_void,
     }
 }

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -40,15 +40,19 @@ pub struct NewBuffer {
 /// A closure for reporting mutators.  The C++ code should pass `data` back as the last argument.
 #[repr(C)]
 pub struct MutatorClosure {
-    pub func: *const extern "C" fn(mutator: *mut Mutator<OpenJDK>, data: *mut libc::c_void),
+    pub func: extern "C" fn(mutator: *mut Mutator<OpenJDK>, data: *mut libc::c_void),
     pub data: *mut libc::c_void,
 }
 
 /// A closure for reporting root edges.  The C++ code should pass `data` back as the last argument.
 #[repr(C)]
 pub struct EdgesClosure {
-    pub func:
-        *const extern "C" fn(buf: *mut Address, size: usize, cap: usize, data: *const libc::c_void),
+    pub func: extern "C" fn(
+        buf: *mut Address,
+        size: usize,
+        cap: usize,
+        data: *mut libc::c_void,
+    ) -> NewBuffer,
     pub data: *const libc::c_void,
 }
 

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -17,11 +17,11 @@ extern "C" fn report_edges_and_renew_buffer<F: RootsWorkFactory<OpenJDKEdge>>(
     ptr: *mut Address,
     length: usize,
     capacity: usize,
-    factory_ptr: *mut F,
+    factory_ptr: *mut libc::c_void,
 ) -> NewBuffer {
     if !ptr.is_null() {
         let buf = unsafe { Vec::<Address>::from_raw_parts(ptr, length, capacity) };
-        let factory: &mut F = unsafe { &mut *factory_ptr };
+        let factory: &mut F = unsafe { &mut *(factory_ptr as *mut F) };
         factory.create_process_edge_roots_work(buf);
     }
     let (ptr, _, capacity) = {
@@ -36,7 +36,7 @@ extern "C" fn report_edges_and_renew_buffer<F: RootsWorkFactory<OpenJDKEdge>>(
 
 pub(crate) fn to_edges_closure<F: RootsWorkFactory<OpenJDKEdge>>(factory: &mut F) -> EdgesClosure {
     EdgesClosure {
-        func: report_edges_and_renew_buffer::<F> as *const _,
+        func: report_edges_and_renew_buffer::<F>,
         data: factory as *mut F as *mut libc::c_void,
     }
 }


### PR DESCRIPTION
That was a mistake.  I wrote `*const extern "C" fn(...)` and thought that was function pointer type, but it is actually "a pointer to a pointer to a function".  The type of a function pointer to a plain function with C calling convention is just `extern "C" fn(....)`.

p.s. I wonder why this has been working so far.  Maybe the Rust side used an unsafe cast to write the right function pointer to a field with wrong pointer type, and the C++ side's signature is actually correct. So it worked even though the typing was incorrect.