### PR TITLE
Workaround soft_ref_policy crash

### DIFF
--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -63,8 +63,14 @@ object iterator??!!
 
 MMTkHeap* MMTkHeap::_heap = NULL;
 
-MMTkHeap::MMTkHeap(MMTkCollectorPolicy* policy) : CollectedHeap(), _last_gc_time(0), _collector_policy(policy),  _num_root_scan_tasks(0), _n_workers(0), _gc_lock(new Monitor(Mutex::safepoint, "MMTkHeap::_gc_lock", true, Monitor::_safepoint_check_sometimes))
-// , _par_state_string(StringTable::weak_storage())
+MMTkHeap::MMTkHeap(MMTkCollectorPolicy* policy) :
+  CollectedHeap(),
+  _last_gc_time(0),
+  _collector_policy(policy),
+  _num_root_scan_tasks(0),
+  _n_workers(0),
+  _gc_lock(new Monitor(Mutex::safepoint, "MMTkHeap::_gc_lock", true, Monitor::_safepoint_check_sometimes)),
+  _soft_ref_policy()
 {
   _heap = this;
 }
@@ -255,7 +261,7 @@ void MMTkHeap::do_full_collection(bool clear_all_soft_refs) {//later when gc is 
 // Return the CollectorPolicy for the heap
 CollectorPolicy* MMTkHeap::collector_policy() const {return _collector_policy;}//OK
 
-SoftRefPolicy* MMTkHeap::soft_ref_policy() {return _soft_ref_policy;}//OK
+SoftRefPolicy* MMTkHeap::soft_ref_policy() {return &_soft_ref_policy;}//OK
 
 GrowableArray<GCMemoryManager*> MMTkHeap::memory_managers() {//may cause error
 

--- a/openjdk/mmtkHeap.hpp
+++ b/openjdk/mmtkHeap.hpp
@@ -48,7 +48,7 @@ class MemoryPool;
 class MMTkVMCompanionThread;
 class MMTkHeap : public CollectedHeap {
   MMTkCollectorPolicy* _collector_policy;
-  SoftRefPolicy* _soft_ref_policy;
+  SoftRefPolicy _soft_ref_policy;
   MMTkMemoryPool* _mmtk_pool;
   GCMemoryManager* _mmtk_manager;
   HeapWord* _start;


### PR DESCRIPTION
Sometimes the VM will call methods of CollectedHeap::soft_ref_policy(). If it returns nullptr, the VM will crash for SIGSEGV in a subsequent method invocation on the returned nullptr.

This is just a workaround because our soft reference processor is currently implemented in mmtk-core.
