### PR TITLE
#include arrayOop.hpp in mmtkBarrierSet.hpp

### DIFF
--- a/openjdk/mmtkBarrierSet.hpp
+++ b/openjdk/mmtkBarrierSet.hpp
@@ -32,6 +32,7 @@
 #include "mmtk.h"
 #include "mmtkBarrierSetAssembler_x86.hpp"
 #include "oops/access.hpp"
+#include "oops/arrayOop.hpp"
 #include "oops/accessBackend.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/fakeRttiSupport.hpp"


### PR DESCRIPTION
This is a dependency, and without this include, it causes a build failure with our local build configuration. (Possibly related to `--disable-precompiled-headers`, but haven't confirmed which exact flag causes this issue.) 