### PR TITLE
Add new correctness CI

### DIFF
--- a/.github/configs/base.yml
+++ b/.github/configs/base.yml
@@ -1,0 +1,86 @@
+includes:
+  - "$RUNNING_NG_PACKAGE_DATA/base/runbms.yml"
+
+suites:
+  dacapochopin-04132797-ci:
+    type: DaCapo
+    release: evaluation
+    path: "DACAPO_PATH/dacapo-evaluation-git-04132797.jar"
+    minheap: mmtk-openjdk-11-MarkCompact
+    minheap_values:
+      mmtk-openjdk-11-MarkCompact:
+        avrora: 8
+        batik: 426
+        biojava: 197
+        cassandra: 117
+        eclipse: 439
+        fop: 24
+        graphchi: 195
+        h2: 1122
+        h2o: 136
+        jme: 236
+        jython: 48
+        kafka: 243
+        luindex: 25
+        lusearch: 36
+        pmd: 291
+        spring: 110
+        sunflow: 37
+        tradebeans: .inf
+        tradesoap: .inf
+        tomcat: 55
+        xalan: 19
+        zxing: 427
+      nominal-heap-sizes:
+        avrora: 7
+        batik: 192
+        biojava: 97
+        cassandra: 74
+        eclipse: 346
+        fop: 17
+        graphchi: 179
+        h2: 506
+        h2o: 102
+        jme: 29
+        jython: 29
+        kafka: 207
+        luindex: 44
+        lusearch: 19
+        pmd: 114
+        spring: 47
+        sunflow: 25
+        tradebeans: 101
+        tradesoap: 89
+        tomcat: 17
+        xalan: 9
+        zxing: 66
+    timing_iteration: 3
+    timeout: 900
+
+overrides:
+  invocations: 3
+  remote_host: null
+
+modifiers:
+  mmtk_gc:
+    type: "EnvVar"
+    var: "MMTK_PLAN"
+    val: "{0}"
+
+runtimes:
+  jdk11-master:
+    type: OpenJDK
+    release: 11
+    home: "/home/runner/work/mmtk-ci/mmtk-ci/bundles/jdk"
+
+configs:
+  - "jdk11-master|ms|s|c2|mmtk_gc-SemiSpace|tph"
+  - "jdk11-master|ms|s|c2|mmtk_gc-GenCopy|tph"
+  - "jdk11-master|ms|s|c2|mmtk_gc-Immix|tph"
+  - "jdk11-master|ms|s|c2|mmtk_gc-GenImmix|tph"
+  - "jdk11-master|ms|s|c2|mmtk_gc-StickyImmix|tph"
+  - "jdk11-master|ms|s|c2|mmtk_gc-MarkSweep|tph"
+  - "jdk11-master|ms|s|c2|mmtk_gc-MarkCompact|tph"
+
+benchmarks:
+  dacapochopin-04132797-ci:

--- a/.github/configs/base.yml
+++ b/.github/configs/base.yml
@@ -74,13 +74,13 @@ runtimes:
     home: "/home/runner/work/mmtk-openjdk/mmtk-openjdk/bundles/jdk"
 
 configs:
-  - "jdk11-master|ms|s|c2|mmtk_gc-SemiSpace|tph"
-  - "jdk11-master|ms|s|c2|mmtk_gc-GenCopy|tph"
-  - "jdk11-master|ms|s|c2|mmtk_gc-Immix|tph"
-  - "jdk11-master|ms|s|c2|mmtk_gc-GenImmix|tph"
-  - "jdk11-master|ms|s|c2|mmtk_gc-StickyImmix|tph"
-  - "jdk11-master|ms|s|c2|mmtk_gc-MarkSweep|tph"
-  - "jdk11-master|ms|s|c2|mmtk_gc-MarkCompact|tph"
+  - "jdk11-master|ms|s|mmtk_gc-SemiSpace|tph"
+  - "jdk11-master|ms|s|mmtk_gc-GenCopy|tph"
+  - "jdk11-master|ms|s|mmtk_gc-Immix|tph"
+  - "jdk11-master|ms|s|mmtk_gc-GenImmix|tph"
+  - "jdk11-master|ms|s|mmtk_gc-StickyImmix|tph"
+  - "jdk11-master|ms|s|mmtk_gc-MarkSweep|tph"
+  - "jdk11-master|ms|s|mmtk_gc-MarkCompact|tph"
 
 benchmarks:
   dacapochopin-04132797-ci:

--- a/.github/configs/base.yml
+++ b/.github/configs/base.yml
@@ -71,7 +71,7 @@ runtimes:
   jdk11-master:
     type: OpenJDK
     release: 11
-    home: "/home/runner/work/mmtk-ci/mmtk-ci/bundles/jdk"
+    home: "/home/runner/work/mmtk-openjdk/mmtk-openjdk/bundles/jdk"
 
 configs:
   - "jdk11-master|ms|s|c2|mmtk_gc-SemiSpace|tph"

--- a/.github/scripts/build-normal.sh
+++ b/.github/scripts/build-normal.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -xe
+
+. $(dirname "$0")/new-common.sh
+
+# Use fastdebug if DEBUG_LEVEL is unset
+DEBUG_LEVEL=${DEBUG_LEVEL:="fastdebug"}
+
+# Build product bundle
+cd $OPENJDK_PATH
+sh configure --disable-warnings-as-errors --with-debug-level=$DEBUG_LEVEL
+make CONF=linux-x86_64-normal-server-$DEBUG_LEVEL THIRD_PARTY_HEAP=$BINDING_PATH/openjdk product-bundles
+
+if [[ $DEBUG_LEVEL == "fastdebug" ]]; then
+    pushd build/linux-x86_64-normal-server-fastdebug/bundles
+    F=`ls *_bin-debug.tar.gz`
+    mv $F ${F/_bin-debug/_bin}
+    popd
+fi

--- a/.github/scripts/new-common.sh
+++ b/.github/scripts/new-common.sh
@@ -1,0 +1,4 @@
+BINDING_PATH=$(realpath $(dirname "$0"))/../..
+OPENJDK_PATH=$BINDING_PATH/../openjdk
+DACAPO_PATH=$BINDING_PATH/../dacapo
+RUSTUP_TOOLCHAIN=`cat $BINDING_PATH/mmtk/rust-toolchain`

--- a/.github/scripts/pgo-build.sh
+++ b/.github/scripts/pgo-build.sh
@@ -7,7 +7,7 @@ RUSTFLAGS="-Cprofile-generate=/tmp/$USER/pgo-data" make CONF=linux-x86_64-normal
 rm -rf /tmp/$USER/pgo-data/*
 
 # Profile using fop
-MMTK_PLAN=GenImmix MMTK_STRESS_FACTOR=4194304 MMTK_PRECISE_STRESS=false ./build/linux-x86_64-normal-server-release/images/jdk/bin/java -XX:MetaspaceSize=500M -XX:+DisableExplicitGC -XX:-TieredCompilation -Xcomp -XX:+UseThirdPartyHeap -Xms60M -Xmx60M -jar /usr/share/benchmarks/dacapo/dacapo-evaluation-git-6e411f33.jar -n 5 fop
+MMTK_PLAN=GenImmix MMTK_STRESS_FACTOR=16777216 MMTK_PRECISE_STRESS=false ./build/linux-x86_64-normal-server-release/images/jdk/bin/java -XX:MetaspaceSize=500M -XX:+DisableExplicitGC -XX:-TieredCompilation -Xcomp -XX:+UseThirdPartyHeap -Xms60M -Xmx60M -jar /usr/share/benchmarks/dacapo/dacapo-evaluation-git-6e411f33.jar -n 5 fop
 
 # Merge profiling data
 /opt/rust/toolchains/1.66.1-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -o /tmp/$USER/pgo-data/merged.profdata /tmp/$USER/pgo-data

--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -xe
+
+. $(dirname "$0")/new-common.sh
+
+# Install nightly rust
+rustup toolchain install $RUSTUP_TOOLCHAIN
+rustup target add i686-unknown-linux-gnu --toolchain $RUSTUP_TOOLCHAIN
+rustup component add clippy --toolchain $RUSTUP_TOOLCHAIN
+rustup component add rustfmt --toolchain $RUSTUP_TOOLCHAIN
+rustup override set $RUSTUP_TOOLCHAIN
+
+# Install running
+pip3 install running-ng
+
+# Install dependencies
+sudo apt-get update -y
+sudo apt-get install dos2unix
+sudo apt-get install build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev

--- a/.github/scripts/style-check.sh
+++ b/.github/scripts/style-check.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -xe
+
+. $(dirname "$0")/new-common.sh
+
+export RUSTFLAGS="-D warnings"
+
+pushd $BINDING_PATH/mmtk
+cargo clippy || exit $?
+cargo clippy --release || exit $?
+
+cargo fmt -- --check || exit $?
+popd
+
+find $BINDING_PATH/openjdk \
+    $BINDING_PATH/mmtk \
+    -name '*.hpp' \
+    -o -name '*.cpp' \
+    -o -name '*.rs' \
+    -o -name '*.toml' \
+    -o -name '*.gmk' \
+    -exec $(dirname "$0")/ci-check-lineends.sh '{}' \;
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,142 @@
+name: "Continuous Integration"
+
+on:
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-linux-x64:
+    name: linux-x64
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: true
+      matrix:
+        debug-level: ["fastdebug", "release"]
+    steps:
+      - name: Checkout MMTk OpenJDK binding
+        uses: actions/checkout@v3
+        with:
+          path: ./git/mmtk-openjdk
+      - name: Extract OpenJDK revision
+        id: extract-openjdk-revision
+        run: |
+          OPENJDK_VERSION=`sed -n 's/^openjdk_version.=."\(.*\)"$/\1/p' < git/mmtk-openjdk/mmtk/Cargo.toml`
+          echo "openjdk-revision=$OPENJDK_VERSION" >> $GITHUB_OUTPUT
+      - name: Checkout OpenJDK
+        uses: actions/checkout@v3
+        with:
+          repository: mmtk/openjdk
+          path: ./git/openjdk
+          ref: ${{ steps.extract-openjdk-revision.outputs.openjdk-revision }}
+      - name: Setup environment
+        run: ./.github/scripts/setup.sh
+        working-directory: ./git/mmtk-openjdk
+      - name: Style checks
+        run: ./.github/scripts/style-check.sh
+        working-directory: ./git/mmtk-openjdk
+      - name: Build MMTk OpenJDK ${{ matrix.debug-level }}
+        run: DEBUG_LEVEL=${{ matrix.debug-level }} ./.github/scripts/build-normal.sh
+        working-directory: ./git/mmtk-openjdk
+      - name: Upload bundles
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
+          path: ./git/openjdk/build/linux-x86_64-normal-server-${{ matrix.debug-level }}/bundles/*_bin.tar.gz
+          retention-days: 2
+
+  test-linux-x64:
+    name: linux-x64
+    needs:
+      - build-linux-x64
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        debug-level: ["fastdebug", "release"]
+        benchmark:
+          - avrora
+          - batik
+          - biojava
+          - cassandra
+          - eclipse
+          - fop
+          - graphchi
+          - h2
+          - h2o
+          - jme
+          - jython
+          - kafka
+          - luindex
+          - lusearch
+          - pmd
+          # spring
+          - sunflow
+          - tomcat
+          # tradebeans
+          # tradesoap
+          - xalan
+          - zxing
+    steps:
+      - name: Checkout MMTk OpenJDK binding
+        uses: actions/checkout@v3
+      - name: Setup environment
+        run: |
+          pip3 install running-ng
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev
+      - name: Cache DaCapo Chopin git-04132797
+        id: dacapo-04132797
+        uses: actions/cache@v3
+        with:
+          path: dacapo/dacapo-evaluation-git-04132797.zip
+          key: dacapo-chopin-git-04132797
+      - name: Install DaCapo Chopin git-04132797
+        if: steps.dacapo-04132797.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p dacapo
+          pushd dacapo
+          wget -q "https://cloudstor.aarnet.edu.au/plus/s/9cMreAgANcMUOzq/download" -O dacapo-evaluation-git-04132797.zip
+          popd
+      - name: Unzip DaCapo Chopin git-04132797
+        run: |
+          pushd dacapo
+          unzip dacapo-evaluation-git-04132797.zip
+          popd
+      - name: Download bundles
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
+          path: bundles
+      - name: Extract OpenJDK
+        run: |
+          pushd bundles
+          tar xvf *.tar.gz
+          BIN_DIR=`find . -name bin`
+          mv `dirname $BIN_DIR` jdk
+          popd
+      - name: Run DaCapo Chopin git-04132797 ${{ matrix.benchmark }} on MMTk OpenJDK ${{ matrix.debug-level }} with 2.5x MarkCompact minheap
+        run: |
+          DACAPO_PATH=`realpath ./dacapo`
+          sed -i "s;DACAPO_PATH;$DACAPO_PATH;g" .github/configs/base.yml
+          echo "    - ${{ matrix.benchmark }}" >> .github/configs/base.yml
+          running runbms /tmp .github/configs/base.yml -s 2.5 -p linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }} | tee /tmp/running.stdout
+      - name: Extract running run id
+        id: extract-running-run-id
+        run: |
+          RUN_ID=`sed -n 's/^Run id:.\(.*\)$/\1/p' < /tmp/running.stdout`
+          echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
+      - name: Upload running artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }}
+          path: /tmp/${{ steps.extract-running-run-id.outputs.run-id }}/
+      - name: Check for test failures
+        run: |
+          RUNNING_OUTPUT=`sed -n "s/^\(${{ matrix.benchmark }} .*\)$/\1/p" < /tmp/running.stdout`
+          echo $RUNNING_OUTPUT
+          echo $RUNNING_OUTPUT | grep -vq "\."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,85 +10,85 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # build-linux-x64:
-  #   name: linux-x64
-  #   runs-on: ubuntu-22.04
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       debug-level: ["fastdebug", "release"]
-  #   steps:
-  #     - name: Checkout MMTk OpenJDK binding
-  #       uses: actions/checkout@v3
-  #       with:
-  #         path: ./git/mmtk-openjdk
-  #     - name: Extract OpenJDK revision
-  #       id: extract-openjdk-revision
-  #       run: |
-  #         OPENJDK_VERSION=`sed -n 's/^openjdk_version.=."\(.*\)"$/\1/p' < git/mmtk-openjdk/mmtk/Cargo.toml`
-  #         echo "openjdk-revision=$OPENJDK_VERSION" >> $GITHUB_OUTPUT
-  #     - name: Checkout OpenJDK
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: mmtk/openjdk
-  #         path: ./git/openjdk
-  #         ref: ${{ steps.extract-openjdk-revision.outputs.openjdk-revision }}
-  #     - name: Setup environment
-  #       run: ./.github/scripts/setup.sh
-  #       working-directory: ./git/mmtk-openjdk
-  #     - name: Style checks
-  #       run: ./.github/scripts/style-check.sh
-  #       working-directory: ./git/mmtk-openjdk
-  #     - name: Build MMTk OpenJDK ${{ matrix.debug-level }}
-  #       run: DEBUG_LEVEL=${{ matrix.debug-level }} ./.github/scripts/build-normal.sh
-  #       working-directory: ./git/mmtk-openjdk
-  #     - name: Upload bundles
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
-  #         path: ./git/openjdk/build/linux-x86_64-normal-server-${{ matrix.debug-level }}/bundles/*_bin.tar.gz
-  #         retention-days: 2
+  build-linux-x64:
+    name: linux-x64
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: true
+      matrix:
+        debug-level: ["fastdebug", "release"]
+    steps:
+      - name: Checkout MMTk OpenJDK binding
+        uses: actions/checkout@v3
+        with:
+          path: ./git/mmtk-openjdk
+      - name: Extract OpenJDK revision
+        id: extract-openjdk-revision
+        run: |
+          OPENJDK_VERSION=`sed -n 's/^openjdk_version.=."\(.*\)"$/\1/p' < git/mmtk-openjdk/mmtk/Cargo.toml`
+          echo "openjdk-revision=$OPENJDK_VERSION" >> $GITHUB_OUTPUT
+      - name: Checkout OpenJDK
+        uses: actions/checkout@v3
+        with:
+          repository: mmtk/openjdk
+          path: ./git/openjdk
+          ref: ${{ steps.extract-openjdk-revision.outputs.openjdk-revision }}
+      - name: Setup environment
+        run: ./.github/scripts/setup.sh
+        working-directory: ./git/mmtk-openjdk
+      - name: Style checks
+        run: ./.github/scripts/style-check.sh
+        working-directory: ./git/mmtk-openjdk
+      - name: Build MMTk OpenJDK ${{ matrix.debug-level }}
+        run: DEBUG_LEVEL=${{ matrix.debug-level }} ./.github/scripts/build-normal.sh
+        working-directory: ./git/mmtk-openjdk
+      - name: Upload bundles
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
+          path: ./git/openjdk/build/linux-x86_64-normal-server-${{ matrix.debug-level }}/bundles/*_bin.tar.gz
+          retention-days: 2
 
   test-linux-x64:
     name: linux-x64
-    # needs:
-    #   - build-linux-x64
+    needs:
+      - build-linux-x64
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        debug-level: ["release"]
+        debug-level: ["fastdebug", "release"]
         benchmark:
           - avrora
-          # - batik
-          # - biojava
-          # - cassandra
-          # - eclipse
-          # - fop
-          # - graphchi
-          # - h2
-          # - h2o
-          # - jme
-          # - jython
-          # - kafka
-          # - luindex
-          # - lusearch
-          # - pmd
-          # # spring
-          # - sunflow
-          # - tomcat
-          # # tradebeans
-          # # tradesoap
-          # - xalan
-          # - zxing
+          - batik
+          - biojava
+          - cassandra
+          - eclipse
+          - fop
+          - graphchi
+          - h2
+          - h2o
+          - jme
+          - jython
+          - kafka
+          - luindex
+          - lusearch
+          - pmd
+          # spring
+          - sunflow
+          - tomcat
+          # tradebeans
+          # tradesoap
+          - xalan
+          - zxing
     steps:
       - name: Checkout MMTk OpenJDK binding
         uses: actions/checkout@v3
-      # name: Setup environment
-      # run: |
-      #   pip3 install running-ng
-      #   sudo apt-get update -y
-      #   sudo apt-get install -y build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev
+      - name: Setup environment
+        run: |
+          pip3 install running-ng
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev
       - name: Cache DaCapo Chopin git-04132797
         id: dacapo-04132797
         uses: actions/cache@v3
@@ -102,41 +102,41 @@ jobs:
           pushd dacapo
           wget -q "https://cloudstor.aarnet.edu.au/plus/s/9cMreAgANcMUOzq/download" -O dacapo-evaluation-git-04132797.zip
           popd
-      # name: Unzip DaCapo Chopin git-04132797
-      # run: |
-      #   pushd dacapo
-      #   unzip dacapo-evaluation-git-04132797.zip
-      #   popd
-      # name: Download bundles
-      # uses: actions/download-artifact@v3
-      # with:
-      #   name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
-      #   path: bundles
-      # name: Extract OpenJDK
-      # run: |
-      #   pushd bundles
-      #   tar xvf *.tar.gz
-      #   BIN_DIR=`find . -name bin`
-      #   mv `dirname $BIN_DIR` jdk
-      #   popd
-      # name: Run DaCapo Chopin git-04132797 ${{ matrix.benchmark }} on MMTk OpenJDK ${{ matrix.debug-level }} with 2.5x MarkCompact minheap
-      # run: |
-      #   DACAPO_PATH=`realpath ./dacapo`
-      #   sed -i "s;DACAPO_PATH;$DACAPO_PATH;g" .github/configs/base.yml
-      #   echo "    - ${{ matrix.benchmark }}" >> .github/configs/base.yml
-      #   running runbms /tmp .github/configs/base.yml -s 2.5 -p linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }} | tee /tmp/running.stdout
-      # name: Extract running run id
-      # id: extract-running-run-id
-      # run: |
-      #   RUN_ID=`sed -n 's/^Run id:.\(.*\)$/\1/p' < /tmp/running.stdout`
-      #   echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
-      # name: Upload running artifacts
-      # uses: actions/upload-artifact@v3
-      # with:
-      #   name: linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }}
-      #   path: /tmp/${{ steps.extract-running-run-id.outputs.run-id }}/
-      # name: Check for test failures
-      # run: |
-      #   RUNNING_OUTPUT=`sed -n "s/^\(${{ matrix.benchmark }} .*\)$/\1/p" < /tmp/running.stdout`
-      #   echo $RUNNING_OUTPUT
-      #   echo $RUNNING_OUTPUT | grep -vq "\."
+      - name: Unzip DaCapo Chopin git-04132797
+        run: |
+          pushd dacapo
+          unzip dacapo-evaluation-git-04132797.zip
+          popd
+      - name: Download bundles
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
+          path: bundles
+      - name: Extract OpenJDK
+        run: |
+          pushd bundles
+          tar xvf *.tar.gz
+          BIN_DIR=`find . -name bin`
+          mv `dirname $BIN_DIR` jdk
+          popd
+      - name: Run DaCapo Chopin git-04132797 ${{ matrix.benchmark }} on MMTk OpenJDK ${{ matrix.debug-level }} with 2.5x MarkCompact minheap
+        run: |
+          DACAPO_PATH=`realpath ./dacapo`
+          sed -i "s;DACAPO_PATH;$DACAPO_PATH;g" .github/configs/base.yml
+          echo "    - ${{ matrix.benchmark }}" >> .github/configs/base.yml
+          running runbms /tmp .github/configs/base.yml -s 2.5 -p linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }} | tee /tmp/running.stdout
+      - name: Extract running run id
+        id: extract-running-run-id
+        run: |
+          RUN_ID=`sed -n 's/^Run id:.\(.*\)$/\1/p' < /tmp/running.stdout`
+          echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
+      - name: Upload running artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }}
+          path: /tmp/${{ steps.extract-running-run-id.outputs.run-id }}/
+      - name: Check for test failures
+        run: |
+          RUNNING_OUTPUT=`sed -n "s/^\(${{ matrix.benchmark }} .*\)$/\1/p" < /tmp/running.stdout`
+          echo $RUNNING_OUTPUT
+          echo $RUNNING_OUTPUT | grep -vq "\."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,85 +10,85 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-linux-x64:
-    name: linux-x64
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: true
-      matrix:
-        debug-level: ["fastdebug", "release"]
-    steps:
-      - name: Checkout MMTk OpenJDK binding
-        uses: actions/checkout@v3
-        with:
-          path: ./git/mmtk-openjdk
-      - name: Extract OpenJDK revision
-        id: extract-openjdk-revision
-        run: |
-          OPENJDK_VERSION=`sed -n 's/^openjdk_version.=."\(.*\)"$/\1/p' < git/mmtk-openjdk/mmtk/Cargo.toml`
-          echo "openjdk-revision=$OPENJDK_VERSION" >> $GITHUB_OUTPUT
-      - name: Checkout OpenJDK
-        uses: actions/checkout@v3
-        with:
-          repository: mmtk/openjdk
-          path: ./git/openjdk
-          ref: ${{ steps.extract-openjdk-revision.outputs.openjdk-revision }}
-      - name: Setup environment
-        run: ./.github/scripts/setup.sh
-        working-directory: ./git/mmtk-openjdk
-      - name: Style checks
-        run: ./.github/scripts/style-check.sh
-        working-directory: ./git/mmtk-openjdk
-      - name: Build MMTk OpenJDK ${{ matrix.debug-level }}
-        run: DEBUG_LEVEL=${{ matrix.debug-level }} ./.github/scripts/build-normal.sh
-        working-directory: ./git/mmtk-openjdk
-      - name: Upload bundles
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
-          path: ./git/openjdk/build/linux-x86_64-normal-server-${{ matrix.debug-level }}/bundles/*_bin.tar.gz
-          retention-days: 2
+  # build-linux-x64:
+  #   name: linux-x64
+  #   runs-on: ubuntu-22.04
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       debug-level: ["fastdebug", "release"]
+  #   steps:
+  #     - name: Checkout MMTk OpenJDK binding
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: ./git/mmtk-openjdk
+  #     - name: Extract OpenJDK revision
+  #       id: extract-openjdk-revision
+  #       run: |
+  #         OPENJDK_VERSION=`sed -n 's/^openjdk_version.=."\(.*\)"$/\1/p' < git/mmtk-openjdk/mmtk/Cargo.toml`
+  #         echo "openjdk-revision=$OPENJDK_VERSION" >> $GITHUB_OUTPUT
+  #     - name: Checkout OpenJDK
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: mmtk/openjdk
+  #         path: ./git/openjdk
+  #         ref: ${{ steps.extract-openjdk-revision.outputs.openjdk-revision }}
+  #     - name: Setup environment
+  #       run: ./.github/scripts/setup.sh
+  #       working-directory: ./git/mmtk-openjdk
+  #     - name: Style checks
+  #       run: ./.github/scripts/style-check.sh
+  #       working-directory: ./git/mmtk-openjdk
+  #     - name: Build MMTk OpenJDK ${{ matrix.debug-level }}
+  #       run: DEBUG_LEVEL=${{ matrix.debug-level }} ./.github/scripts/build-normal.sh
+  #       working-directory: ./git/mmtk-openjdk
+  #     - name: Upload bundles
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
+  #         path: ./git/openjdk/build/linux-x86_64-normal-server-${{ matrix.debug-level }}/bundles/*_bin.tar.gz
+  #         retention-days: 2
 
   test-linux-x64:
     name: linux-x64
-    needs:
-      - build-linux-x64
+    # needs:
+    #   - build-linux-x64
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        debug-level: ["fastdebug", "release"]
+        debug-level: ["release"]
         benchmark:
           - avrora
-          - batik
-          - biojava
-          - cassandra
-          - eclipse
-          - fop
-          - graphchi
-          - h2
-          - h2o
-          - jme
-          - jython
-          - kafka
-          - luindex
-          - lusearch
-          - pmd
-          # spring
-          - sunflow
-          - tomcat
-          # tradebeans
-          # tradesoap
-          - xalan
-          - zxing
+          # - batik
+          # - biojava
+          # - cassandra
+          # - eclipse
+          # - fop
+          # - graphchi
+          # - h2
+          # - h2o
+          # - jme
+          # - jython
+          # - kafka
+          # - luindex
+          # - lusearch
+          # - pmd
+          # # spring
+          # - sunflow
+          # - tomcat
+          # # tradebeans
+          # # tradesoap
+          # - xalan
+          # - zxing
     steps:
       - name: Checkout MMTk OpenJDK binding
         uses: actions/checkout@v3
-      - name: Setup environment
-        run: |
-          pip3 install running-ng
-          sudo apt-get update -y
-          sudo apt-get install -y build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev
+      # name: Setup environment
+      # run: |
+      #   pip3 install running-ng
+      #   sudo apt-get update -y
+      #   sudo apt-get install -y build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev
       - name: Cache DaCapo Chopin git-04132797
         id: dacapo-04132797
         uses: actions/cache@v3
@@ -102,41 +102,41 @@ jobs:
           pushd dacapo
           wget -q "https://cloudstor.aarnet.edu.au/plus/s/9cMreAgANcMUOzq/download" -O dacapo-evaluation-git-04132797.zip
           popd
-      - name: Unzip DaCapo Chopin git-04132797
-        run: |
-          pushd dacapo
-          unzip dacapo-evaluation-git-04132797.zip
-          popd
-      - name: Download bundles
-        uses: actions/download-artifact@v3
-        with:
-          name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
-          path: bundles
-      - name: Extract OpenJDK
-        run: |
-          pushd bundles
-          tar xvf *.tar.gz
-          BIN_DIR=`find . -name bin`
-          mv `dirname $BIN_DIR` jdk
-          popd
-      - name: Run DaCapo Chopin git-04132797 ${{ matrix.benchmark }} on MMTk OpenJDK ${{ matrix.debug-level }} with 2.5x MarkCompact minheap
-        run: |
-          DACAPO_PATH=`realpath ./dacapo`
-          sed -i "s;DACAPO_PATH;$DACAPO_PATH;g" .github/configs/base.yml
-          echo "    - ${{ matrix.benchmark }}" >> .github/configs/base.yml
-          running runbms /tmp .github/configs/base.yml -s 2.5 -p linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }} | tee /tmp/running.stdout
-      - name: Extract running run id
-        id: extract-running-run-id
-        run: |
-          RUN_ID=`sed -n 's/^Run id:.\(.*\)$/\1/p' < /tmp/running.stdout`
-          echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
-      - name: Upload running artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }}
-          path: /tmp/${{ steps.extract-running-run-id.outputs.run-id }}/
-      - name: Check for test failures
-        run: |
-          RUNNING_OUTPUT=`sed -n "s/^\(${{ matrix.benchmark }} .*\)$/\1/p" < /tmp/running.stdout`
-          echo $RUNNING_OUTPUT
-          echo $RUNNING_OUTPUT | grep -vq "\."
+      # name: Unzip DaCapo Chopin git-04132797
+      # run: |
+      #   pushd dacapo
+      #   unzip dacapo-evaluation-git-04132797.zip
+      #   popd
+      # name: Download bundles
+      # uses: actions/download-artifact@v3
+      # with:
+      #   name: linux-x86_64-server-${{ matrix.debug-level }}-bundles
+      #   path: bundles
+      # name: Extract OpenJDK
+      # run: |
+      #   pushd bundles
+      #   tar xvf *.tar.gz
+      #   BIN_DIR=`find . -name bin`
+      #   mv `dirname $BIN_DIR` jdk
+      #   popd
+      # name: Run DaCapo Chopin git-04132797 ${{ matrix.benchmark }} on MMTk OpenJDK ${{ matrix.debug-level }} with 2.5x MarkCompact minheap
+      # run: |
+      #   DACAPO_PATH=`realpath ./dacapo`
+      #   sed -i "s;DACAPO_PATH;$DACAPO_PATH;g" .github/configs/base.yml
+      #   echo "    - ${{ matrix.benchmark }}" >> .github/configs/base.yml
+      #   running runbms /tmp .github/configs/base.yml -s 2.5 -p linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }} | tee /tmp/running.stdout
+      # name: Extract running run id
+      # id: extract-running-run-id
+      # run: |
+      #   RUN_ID=`sed -n 's/^Run id:.\(.*\)$/\1/p' < /tmp/running.stdout`
+      #   echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
+      # name: Upload running artifacts
+      # uses: actions/upload-artifact@v3
+      # with:
+      #   name: linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }}
+      #   path: /tmp/${{ steps.extract-running-run-id.outputs.run-id }}/
+      # name: Check for test failures
+      # run: |
+      #   RUNNING_OUTPUT=`sed -n "s/^\(${{ matrix.benchmark }} .*\)$/\1/p" < /tmp/running.stdout`
+      #   echo $RUNNING_OUTPUT
+      #   echo $RUNNING_OUTPUT | grep -vq "\."


### PR DESCRIPTION
This commit adds a new correctness CI which parallelizes builds and tests. It uses running-ng, the latest DaCapo snapshot, and reuses build artifacts across runs. All running-ng outputs are uploaded as artifacts at the end of the workflow.