### PR TITLE
Remove deprecated const.

### DIFF
--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -32,10 +32,6 @@ const GC_THREAD_KIND_CONTROLLER: libc::c_int = 0;
 const GC_THREAD_KIND_WORKER: libc::c_int = 1;
 
 impl Collection<OpenJDK> for VMCollection {
-    /// With the presence of the "VM companion thread",
-    /// the OpenJDK binding allows any MMTk GC thread to stop/start the world.
-    const COORDINATOR_ONLY_STW: bool = false;
-
     fn stop_all_mutators<F>(tls: VMWorkerThread, mut mutator_visitor: F)
     where
         F: FnMut(&'static mut Mutator<OpenJDK>),


### PR DESCRIPTION
The constant `COORDINATOR_ONLY_STW` is deprecated and has no effect.  Now mmtk-core no longer has "coordinator work".  For a long time, the OpenJDK binding has been using the "companion thread" to invoke a VM operation to stop the world, and that constant has been set to false.