### PR TITLE
Update MMTk core PR #817 (alternative approach)

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -163,6 +163,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d358e0ec5c59a5e1603b933def447096886121660fc680dc1e64a0753981fe3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,7 +430,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=df146b7af6cf41cc7d6996e1ca538fd2b32950f5#df146b7af6cf41cc7d6996e1ca538fd2b32950f5"
+source = "git+https://github.com/ArberSephirotheca/mmtk-core.git?rev=1bd9b39053f5596204c196746f50a2dd51128c7c#1bd9b39053f5596204c196746f50a2dd51128c7c"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -427,6 +438,7 @@ dependencies = [
  "built 0.6.0",
  "cfg-if",
  "crossbeam",
+ "delegate",
  "downcast-rs",
  "enum-map",
  "env_logger",
@@ -448,7 +460,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=df146b7af6cf41cc7d6996e1ca538fd2b32950f5#df146b7af6cf41cc7d6996e1ca538fd2b32950f5"
+source = "git+https://github.com/ArberSephirotheca/mmtk-core.git?rev=1bd9b39053f5596204c196746f50a2dd51128c7c#1bd9b39053f5596204c196746f50a2dd51128c7c"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -96,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
 name = "crossbeam"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,7 +436,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
-source = "git+https://github.com/ArberSephirotheca/mmtk-core.git?rev=1bd9b39053f5596204c196746f50a2dd51128c7c#1bd9b39053f5596204c196746f50a2dd51128c7c"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=de8bbfe623eee5e915f32870de8f81128df8ad41#de8bbfe623eee5e915f32870de8f81128df8ad41"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -454,13 +460,13 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
- "sys-info",
+ "sysinfo",
 ]
 
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
-source = "git+https://github.com/ArberSephirotheca/mmtk-core.git?rev=1bd9b39053f5596204c196746f50a2dd51128c7c#1bd9b39053f5596204c196746f50a2dd51128c7c"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=de8bbfe623eee5e915f32870de8f81128df8ad41#de8bbfe623eee5e915f32870de8f81128df8ad41"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -477,6 +483,15 @@ dependencies = [
  "libc",
  "mmtk",
  "once_cell",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -566,6 +581,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -713,13 +750,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "sys-info"
-version = "0.9.1"
+name = "sysinfo"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+checksum = "02f1dc6930a439cc5d154221b5387d153f8183529b07c19aca24ea31e0a167e1"
 dependencies = [
- "cc",
+ "cfg-if",
+ "core-foundation-sys",
  "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -30,7 +30,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "df146b7af6cf41cc7d6996e1ca538fd2b32950f5" }
+mmtk = { git = "https://github.com/ArberSephirotheca/mmtk-core.git", rev = "1bd9b39053f5596204c196746f50a2dd51128c7c" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -30,7 +30,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/ArberSephirotheca/mmtk-core.git", rev = "1bd9b39053f5596204c196746f50a2dd51128c7c" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "de8bbfe623eee5e915f32870de8f81128df8ad41" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -149,8 +149,7 @@ typedef struct {
     void (*spawn_gc_thread) (void *tls, int kind, void *ctx);
     void (*block_for_gc) ();
     void (*out_of_memory) (void *tls, MMTkAllocationError err_kind);
-    void* (*get_next_mutator) ();
-    void (*reset_mutator_iterator) ();
+    void (*get_mutators) (MutatorClosure closure);
     void (*scan_object) (void* trace, void* object, void* tls);
     void (*dump_object) (void* object);
     size_t (*get_object_size) (void* object);


### PR DESCRIPTION
This is an alternative approach for https://github.com/mmtk/mmtk-openjdk/pull/218 that addresses the upstream API change in https://github.com/mmtk/mmtk-core/pull/817.  This PR simply saves the mutator pointers into a `VecDeque` and embeds it into the iterator.