### PR TITLE
Update to mmtk-core PR #838

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=de8bbfe623eee5e915f32870de8f81128df8ad41#de8bbfe623eee5e915f32870de8f81128df8ad41"
+source = "git+https://github.com/fepicture/mmtk-core.git?rev=b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af#b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=de8bbfe623eee5e915f32870de8f81128df8ad41#de8bbfe623eee5e915f32870de8f81128df8ad41"
+source = "git+https://github.com/fepicture/mmtk-core.git?rev=b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af#b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
-source = "git+https://github.com/fepicture/mmtk-core.git?rev=b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af#b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0#2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
-source = "git+https://github.com/fepicture/mmtk-core.git?rev=b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af#b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0#2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -30,7 +30,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/fepicture/mmtk-core.git", rev = "b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "2ec37bde7955304f3e4bc5f7bed3fbfba3833cc0" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -30,7 +30,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "de8bbfe623eee5e915f32870de8f81128df8ad41" }
+mmtk = { git = "https://github.com/fepicture/mmtk-core.git", rev = "b4d60c26f8c7550c5c0fb6714105f8a7f2ea81af" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -129,7 +129,7 @@ pub extern "C" fn alloc(
     mutator: *mut Mutator<OpenJDK>,
     size: usize,
     align: usize,
-    offset: isize,
+    offset: usize,
     allocator: AllocationSemantics,
 ) -> Address {
     memory_manager::alloc::<OpenJDK>(unsafe { &mut *mutator }, size, align, offset, allocator)

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -72,7 +72,7 @@ impl ObjectModel<OpenJDK> for VMObjectModel {
         ::std::mem::size_of::<usize>()
     }
 
-    fn get_align_offset_when_copied(_object: ObjectReference) -> isize {
+    fn get_align_offset_when_copied(_object: ObjectReference) -> usize {
         0
     }
 

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -44,7 +44,7 @@ extern void* alloc_slow_largeobject(MMTk_Mutator mutator, size_t size,
     size_t align, size_t offset);
 
 extern void post_alloc(MMTk_Mutator mutator, void* refer,
-    int bytes, int allocator);
+    size_t bytes, int allocator);
 
 /// Full pre-barrier
 extern void mmtk_object_reference_write_pre(MMTk_Mutator mutator, void* src, void* slot, void* target);


### PR DESCRIPTION
This PR updates mmtk-core to https://github.com/mmtk/mmtk-core/pull/838.