### PR TITLE
Pass hotspot command line flags to mmtk-core

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=04a47feb4598b2120598453c2cceec83986c2122#04a47feb4598b2120598453c2cceec83986c2122"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=4873b4ab4016a2a5ef413463443856efa373e90c#4873b4ab4016a2a5ef413463443856efa373e90c"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.18.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=04a47feb4598b2120598453c2cceec83986c2122#04a47feb4598b2120598453c2cceec83986c2122"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=4873b4ab4016a2a5ef413463443856efa373e90c#4873b4ab4016a2a5ef413463443856efa373e90c"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -30,7 +30,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "04a47feb4598b2120598453c2cceec83986c2122" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "4873b4ab4016a2a5ef413463443856efa373e90c" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -18,7 +18,6 @@ use mmtk::MutatorContext;
 use once_cell::sync;
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};
-use std::fmt::Display;
 use std::sync::atomic::Ordering;
 
 // Supported barriers:
@@ -291,35 +290,18 @@ pub extern "C" fn process(name: *const c_char, value: *const c_char) -> bool {
     )
 }
 
-// We trust the name/value pointer is valid.
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-fn set_hotspot_flag_impl<T: Display>(name: *const c_char, value: T) {
-    let name_cstr: &CStr = unsafe { CStr::from_ptr(name) };
-    let name = name_cstr.to_str().unwrap();
+/// Pass hotspot `ParallelGCThreads` flag to mmtk
+#[no_mangle]
+pub extern "C" fn mmtk_builder_set_threads(value: usize) {
     let mut builder = BUILDER.lock().unwrap();
-    let value_str = format!("{}", value);
-    let result = match name {
-        "ParallelGCThreads" => builder.set_option("threads", &value_str),
-        "UseTransparentHugePages" => builder.set_option("transparent_hugepages", &value_str),
-        _ => unimplemented!("Unsupported flag: {}", name),
-    };
-    assert!(
-        result,
-        "Failed to pass hotspot flag {}={} to mmtk-core",
-        name, value
-    );
+    builder.options.threads.set(value);
 }
 
-/// Pass a hotspot integer command line flag to mmtk
+/// Pass hotspot `UseTransparentHugePages` flag to mmtk
 #[no_mangle]
-pub extern "C" fn mmtk_set_hotspot_flag_uint(name: *const c_char, value: u32) {
-    set_hotspot_flag_impl(name, value)
-}
-
-/// Pass a hotspot boolean command line flag to mmtk
-#[no_mangle]
-pub extern "C" fn mmtk_set_hotspot_flag_bool(name: *const c_char, value: bool) {
-    set_hotspot_flag_impl(name, value)
+pub extern "C" fn mmtk_builder_set_transparent_hugepages(value: bool) {
+    let mut builder = BUILDER.lock().unwrap();
+    builder.options.transparent_hugepages.set(value);
 }
 
 #[no_mangle]

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -296,7 +296,6 @@ pub extern "C" fn process(name: *const c_char, value: *const c_char) -> bool {
 fn set_hotspot_flag_impl<T: Display>(name: *const c_char, value: T) {
     let name_cstr: &CStr = unsafe { CStr::from_ptr(name) };
     let name = name_cstr.to_str().unwrap();
-    println!("set {}={}", name, value);
     let mut builder = BUILDER.lock().unwrap();
     let value_str = format!("{}", value);
     let result = match name {

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -211,8 +211,8 @@ extern void add_phantom_candidate(void* ref, void* referent);
 extern void mmtk_harness_begin_impl();
 extern void mmtk_harness_end_impl();
 
-extern void mmtk_set_hotspot_flag_uint(const char* name, unsigned int value);
-extern void mmtk_set_hotspot_flag_bool(const char* name, bool value);
+extern void mmtk_builder_set_threads(size_t value);
+extern void mmtk_builder_set_transparent_hugepages(bool value);
 
 #ifdef __cplusplus
 }

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -211,6 +211,9 @@ extern void add_phantom_candidate(void* ref, void* referent);
 extern void mmtk_harness_begin_impl();
 extern void mmtk_harness_end_impl();
 
+extern void mmtk_set_hotspot_flag_uint(const char* name, unsigned int value);
+extern void mmtk_set_hotspot_flag_bool(const char* name, bool value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -88,6 +88,8 @@ jint MMTkHeap::initialize() {
     bool set_options = process_bulk(strdup(ThirdPartyHeapOptions));
     guarantee(set_options, "Failed to set MMTk options. Please check if the options are valid: %s\n", ThirdPartyHeapOptions);
   }
+  mmtk_set_hotspot_flag_uint("ParallelGCThreads", ParallelGCThreads);
+  mmtk_set_hotspot_flag_bool("UseTransparentHugePages", UseTransparentHugePages);
   // Set heap size
   bool set_heap_size = mmtk_set_heap_size(min_heap_size, max_heap_size);
   guarantee(set_heap_size, "Failed to set MMTk heap size. Please check if the heap size is valid: min = %ld, max = %ld\n", min_heap_size, max_heap_size);

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -84,8 +84,8 @@ jint MMTkHeap::initialize() {
   //  printf("policy max heap size %zu, min heap size %zu\n", heap_size, collector_policy()->min_heap_byte_size());
 
   // Set options
-  mmtk_set_hotspot_flag_uint("ParallelGCThreads", ParallelGCThreads);
-  mmtk_set_hotspot_flag_bool("UseTransparentHugePages", UseTransparentHugePages);
+  mmtk_builder_set_threads(ParallelGCThreads);
+  mmtk_builder_set_transparent_hugepages(UseTransparentHugePages);
   if (ThirdPartyHeapOptions != NULL) {
     bool set_options = process_bulk(strdup(ThirdPartyHeapOptions));
     guarantee(set_options, "Failed to set MMTk options. Please check if the options are valid: %s\n", ThirdPartyHeapOptions);

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -84,12 +84,12 @@ jint MMTkHeap::initialize() {
   //  printf("policy max heap size %zu, min heap size %zu\n", heap_size, collector_policy()->min_heap_byte_size());
 
   // Set options
+  mmtk_set_hotspot_flag_uint("ParallelGCThreads", ParallelGCThreads);
+  mmtk_set_hotspot_flag_bool("UseTransparentHugePages", UseTransparentHugePages);
   if (ThirdPartyHeapOptions != NULL) {
     bool set_options = process_bulk(strdup(ThirdPartyHeapOptions));
     guarantee(set_options, "Failed to set MMTk options. Please check if the options are valid: %s\n", ThirdPartyHeapOptions);
   }
-  mmtk_set_hotspot_flag_uint("ParallelGCThreads", ParallelGCThreads);
-  mmtk_set_hotspot_flag_bool("UseTransparentHugePages", UseTransparentHugePages);
   // Set heap size
   bool set_heap_size = mmtk_set_heap_size(min_heap_size, max_heap_size);
   guarantee(set_heap_size, "Failed to set MMTk heap size. Please check if the heap size is valid: min = %ld, max = %ld\n", min_heap_size, max_heap_size);

--- a/openjdk/thirdPartyHeapArguments.cpp
+++ b/openjdk/thirdPartyHeapArguments.cpp
@@ -45,6 +45,12 @@ void ThirdPartyHeapArguments::initialize() {
   FLAG_SET_DEFAULT(UseTLAB, false);
   FLAG_SET_DEFAULT(UseCompressedOops, false);
   FLAG_SET_DEFAULT(UseCompressedClassPointers, false);
+  FLAG_SET_DEFAULT(ParallelGCThreads, Abstract_VM_Version::parallel_worker_threads());
+  if (ParallelGCThreads == 0) {
+    assert(!FLAG_IS_DEFAULT(ParallelGCThreads), "ParallelGCThreads should not be 0.");
+    vm_exit_during_initialization("The flag -XX:+UseUseThirdPartyHeap can not be combined with -XX:ParallelGCThreads=0", NULL);
+  }
+  
 }
 
 CollectedHeap* ThirdPartyHeapArguments::create_heap() {


### PR DESCRIPTION
This PR makes mmtk-core respect to some hotspot command line flags. 

Currently, for mmtk options `threads` and `transparent_hugepage`, mmtk-openjdk will apply the values from hotspot flags (`ParallelGCThreads` and `UseTransparentHugePages` respectively) first. Specifying these options in `ThirdPartyHeapOptions` or env vars can still work and will override the values copied from hotspot flags.