### PR TITLE
Update tests to use dacapo-23.9-RC3-chopin

### DIFF
--- a/.github/configs/base.yml
+++ b/.github/configs/base.yml
@@ -4,7 +4,8 @@ includes:
 suites:
   dacapo-23.9-RC3-chopin-ci:
     type: DaCapo
-    release: rc
+    # Need running-ng to support 23.9
+    release: evaluation
     path: "DACAPO_PATH/dacapo-23.9-RC3-chopin.jar"
     minheap: mmtk-openjdk-11-MarkCompact
     # Min heap values are from dacapo-evaluation-git-04132797

--- a/.github/configs/base.yml
+++ b/.github/configs/base.yml
@@ -2,11 +2,12 @@ includes:
   - "$RUNNING_NG_PACKAGE_DATA/base/runbms.yml"
 
 suites:
-  dacapochopin-04132797-ci:
+  dacapo-23.9-RC3-chopin-ci:
     type: DaCapo
-    release: evaluation
-    path: "DACAPO_PATH/dacapo-evaluation-git-04132797.jar"
+    release: rc
+    path: "DACAPO_PATH/dacapo-23.9-RC3-chopin.jar"
     minheap: mmtk-openjdk-11-MarkCompact
+    # Min heap values are from dacapo-evaluation-git-04132797
     minheap_values:
       mmtk-openjdk-11-MarkCompact:
         avrora: 8
@@ -83,4 +84,4 @@ configs:
   - "jdk11-master|ms|s|mmtk_gc-MarkCompact|tph"
 
 benchmarks:
-  dacapochopin-04132797-ci:
+  dacapo-23.9-RC3-chopin-ci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,6 +178,7 @@ jobs:
           DACAPO_PATH=`realpath ./dacapo`
           sed -i "s;DACAPO_PATH;$DACAPO_PATH;g" .github/configs/base.yml
           echo "    - ${{ matrix.benchmark }}" >> .github/configs/base.yml
+          set -o pipefail
           running runbms /tmp .github/configs/base.yml -s 2.5 -p linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }} | tee /tmp/running.stdout
       - name: Extract running run id
         id: extract-running-run-id

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,6 +150,7 @@ jobs:
         run: |
           pushd dacapo
           unzip ${{ env.DACAPO_FILE }}
+          rm ${{ env.DACAPO_FILE }}
           popd
       - name: Check free space
         run: df -h

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,9 @@ jobs:
           remove-haskell: true
           remove-codeql: true
           remove-docker-images: true
+          # Leave some room for the runner for logging.
+          root-reserve-mb: 4096
+          temp-reserve-mb: 4096
       - name: Check free space
         run: df -h
       - name: Checkout MMTk OpenJDK binding

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           retention-days: 2
 
   cache-dacapo:
-    name: Cache ${{ env.DACAPO_VERSION }}
+    name: Cache Dacapo
     runs-on: ubuntu-22.04
     steps:
       - name: Check ${{ env.DACAPO_VERSION }} cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,8 +129,10 @@ jobs:
           pip3 install running-ng
           sudo apt-get update -y
           sudo apt-get install -y build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev
-      - name: Check free space
-        run: df -h      
+      - name: Check free space and runner log path
+        run: |
+          df -h
+          df /home/runner/runners
       - name: Fetch ${{ env.DACAPO_VERSION }} cache
         id: fetch-cache
         uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  DACAPO_VERSION: dacapo-23.9-RC3-chopin
+  DACAPO_FILE: dacapo-23.9-RC3-chopin.zip
+  DACAPO_DOWNLOAD_URL: https://download.dacapobench.org/chopin/dacapo-23.9-RC3-chopin.zip
+
 jobs:
   build-linux-x64:
     name: linux-x64
@@ -50,22 +55,22 @@ jobs:
           retention-days: 2
 
   cache-dacapo:
-    name: Cache DaCapo Chopin git-04132797
+    name: Cache ${{ env.DACAPO_VERSION }}
     runs-on: ubuntu-22.04
     steps:
-      - name: Check DaCapo Chopin git-04132797 cache
-        id: dacapo-04132797
+      - name: Check ${{ env.DACAPO_VERSION }} cache
+        id: check-cache
         uses: actions/cache@v3
         with:
-          path: dacapo/dacapo-evaluation-git-04132797.zip
-          key: dacapo-chopin-git-04132797
+          path: dacapo/${{ env.DACAPO_FILE }}
+          key: ${{ env.DACAPO_VERSION }}
           lookup-only: true
-      - name: Install DaCapo Chopin git-04132797
-        if: steps.dacapo-04132797.outputs.cache-hit != 'true'
+      - name: Install ${{ env.DACAPO_VERSION }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p dacapo
           pushd dacapo
-          wget -q "https://download.dacapobench.org/dacapo-evaluation-git-04132797.zip" -O dacapo-evaluation-git-04132797.zip
+          wget -q "${{ env.DACAPO_DOWNLOAD_URL }}" -O ${{ env.DACAPO_FILE }}
           popd
 
   test-linux-x64:
@@ -109,28 +114,28 @@ jobs:
           pip3 install running-ng
           sudo apt-get update -y
           sudo apt-get install -y build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev
-      - name: Fetch DaCapo Chopin git-04132797 cache
-        id: dacapo-04132797
+      - name: Fetch ${{ env.DACAPO_VERSION }} cache
+        id: fetch-cache
         uses: actions/cache@v3
         with:
-          path: dacapo/dacapo-evaluation-git-04132797.zip
-          key: dacapo-chopin-git-04132797
+          path: dacapo/${{ env.DACAPO_FILE }}
+          key: ${{ env.DACAPO_VERSION }}
           # fail-on-cache-miss: true    # We should never have a cache miss here as we cache DaCapo in an earlier job
           # Temporarily change this to false in case the cache download gets
           # stuck -- if the cache download is stuck then we go straight to
           # upstream and fetch the zip file
           fail-on-cache-miss: false
-      - name: Install DaCapo Chopin git-04132797
-        if: steps.dacapo-04132797.outputs.cache-hit != 'true'
+      - name: Install ${{ env.DACAPO_VERSION }}
+        if: steps.fetch-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p dacapo
           pushd dacapo
-          wget -q "https://download.dacapobench.org/dacapo-evaluation-git-04132797.zip" -O dacapo-evaluation-git-04132797.zip
+          wget -q "${{ env.DACAPO_DOWNLOAD_URL }}" -O ${{ env.DACAPO_FILE }}
           popd
-      - name: Unzip DaCapo Chopin git-04132797
+      - name: Unzip ${{ env.DACAPO_VERSION }}
         run: |
           pushd dacapo
-          unzip dacapo-evaluation-git-04132797.zip
+          unzip ${{ env.DACAPO_FILE }}
           popd
       - name: Download bundles
         uses: actions/download-artifact@v3
@@ -144,7 +149,7 @@ jobs:
           BIN_DIR=`find . -name bin`
           mv `dirname $BIN_DIR` jdk
           popd
-      - name: Run DaCapo Chopin git-04132797 ${{ matrix.benchmark }} on MMTk OpenJDK ${{ matrix.debug-level }} with 2.5x MarkCompact minheap
+      - name: Run ${{ env.DACAPO_VERSION }} ${{ matrix.benchmark }} on MMTk OpenJDK ${{ matrix.debug-level }} with 2.5x MarkCompact minheap
         run: |
           DACAPO_PATH=`realpath ./dacapo`
           sed -i "s;DACAPO_PATH;$DACAPO_PATH;g" .github/configs/base.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,6 +107,18 @@ jobs:
           - xalan
           - zxing
     steps:
+      - name: Check free space
+        run: df -h
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
+          remove-codeql: true
+          remove-docker-images: true
+      - name: Check free space
+        run: df -h
       - name: Checkout MMTk OpenJDK binding
         uses: actions/checkout@v3
       - name: Setup environment
@@ -114,6 +126,8 @@ jobs:
           pip3 install running-ng
           sudo apt-get update -y
           sudo apt-get install -y build-essential libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libxrandr-dev
+      - name: Check free space
+        run: df -h      
       - name: Fetch ${{ env.DACAPO_VERSION }} cache
         id: fetch-cache
         uses: actions/cache@v3
@@ -137,6 +151,8 @@ jobs:
           pushd dacapo
           unzip ${{ env.DACAPO_FILE }}
           popd
+      - name: Check free space
+        run: df -h
       - name: Download bundles
         uses: actions/download-artifact@v3
         with:
@@ -149,6 +165,8 @@ jobs:
           BIN_DIR=`find . -name bin`
           mv `dirname $BIN_DIR` jdk
           popd
+      - name: Check free space
+        run: df -h
       - name: Run ${{ env.DACAPO_VERSION }} ${{ matrix.benchmark }} on MMTk OpenJDK ${{ matrix.debug-level }} with 2.5x MarkCompact minheap
         run: |
           DACAPO_PATH=`realpath ./dacapo`

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,9 +117,9 @@ jobs:
           remove-haskell: true
           remove-codeql: true
           remove-docker-images: true
-          # Leave some room for the runner for logging.
-          root-reserve-mb: 4096
-          temp-reserve-mb: 4096
+          # Leave some room for the runner for logging in /dev/root
+          root-reserve-mb: 6000
+          temp-reserve-mb: 1024
       - name: Check free space
         run: df -h
       - name: Checkout MMTk OpenJDK binding


### PR DESCRIPTION
The PR changes the CI tests:
* Use dacapo-23.9-RC3-chopin for testing
* Work around the out-of-disk error using `maximize-build-space`
* Properly deal with the return code in the step with `running` when using pipe to redirect output.