### PR TITLE
Fix ignored env var options

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,36 @@ $ ./build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java HelloWorld
 Hello World!
 ```
 
+### Run HelloWorld (with MMTk)
+
+Pass `-XX:+UseThirdPartyHeap` as java command line arguments to enable MMTk.
+
+```
+$ ./build/linux-x86_64-normal-server-$DEBUG_LEVEL/jdk/bin/java -XX:+UseThirdPartyHeap HelloWorld
+```
+
+If `DEBUG_LEVEL` is `release`, you should just see
+
+```
+Hello World!
+```
+
+If `DEBUG_LEVEL` has other values (such as `slowdebug`), you should see logs, too.
+
+```
+[2023-09-14T06:18:46Z INFO  mmtk::memory_manager] Initialized MMTk with GenImmix (DynamicHeapSize(6815744, 8377073664))
+[2023-09-14T06:18:47Z INFO  mmtk::util::heap::gc_trigger] [POLL] nursery: Triggering collection (1670/1664 pages)
+[2023-09-14T06:18:47Z INFO  mmtk::plan::generational::global] Nursery GC
+[2023-09-14T06:18:47Z INFO  mmtk::scheduler::gc_work] End of GC (304/1664 pages, took 19 ms)
+[2023-09-14T06:18:47Z INFO  mmtk::util::heap::gc_trigger] [POLL] nursery: Triggering collection (1680/1664 pages)
+[2023-09-14T06:18:47Z INFO  mmtk::plan::generational::global] Nursery GC
+[2023-09-14T06:18:47Z INFO  mmtk::scheduler::gc_work] End of GC (460/1664 pages, took 11 ms)
+[2023-09-14T06:18:47Z INFO  mmtk::util::heap::gc_trigger] [POLL] nursery: Triggering collection (1674/1664 pages)
+[2023-09-14T06:18:47Z INFO  mmtk::plan::generational::global] Nursery GC
+[2023-09-14T06:18:47Z INFO  mmtk::scheduler::gc_work] End of GC (614/1664 pages, took 11 ms)
+Hello World!
+```
+
 ### Run DaCapo Benchmarks with MMTk
 
 First, fetch DaCapo:
@@ -255,4 +285,25 @@ Using scaled threading model. 24 processors detected, 24 threads used to drive t
 ===== DaCapo 9.12-MR1 lusearch PASSED in 822 msec =====
 ```
 
-**Note:** Pass `-XX:+UseThirdPartyHeap` as java command line arguments to enable MMTk.
+### MMTk options
+
+MMTk has many options defined in https://github.com/mmtk/mmtk-core/blob/master/src/util/options.rs
+
+You can use environment variables started with `MMTK_` to set those options.  For example,
+`export MMTK_THREADS=1` will set the number of GC worker threads to one.  Follow the link above for
+more details.
+
+You can also set those options via command line arguments.
+
+-   `-XX:ParallelGCThreads=n` (where `n` is a number) sets the number of GC worker threads.
+    -   MMTk option: `Options::threads`
+-   `-XX:+UseTransparentHugePages` enables transparent huge pages.
+    -   MMTk option: `Options::transparent_hugepages`
+
+You can also set MMTk options using `-XX:ThirdPartyHeapOptions=options`, where `options` is
+`key=value` pairs separated by commas (`,`).  For example, `stress_factor=1000000,threads=1` will
+set `stress_factor` to 1000000, and `threads` to 1.
+
+Options set via command line arguments take prioritiy over environment variables starting with
+`MMTK_`.  If both the environment variable `MMTK_THREADS=1` and the command line argument
+`-XX:ParallelGCThreads=2` are give, the numberof GC worker threads will be 2.

--- a/README.md
+++ b/README.md
@@ -293,16 +293,19 @@ You can use environment variables started with `MMTK_` to set those options.  Fo
 `export MMTK_THREADS=1` will set the number of GC worker threads to one.  Follow the link above for
 more details.
 
-You can also set those options via command line arguments.
+You can also set those options via command line arguments: `-XX:ThirdPartyHeapOptions=options`,
+where `options` is `key=value` pairs separated by commas (`,`).  For example,
+`-XX:ThirdPartyHeapOptions=stress_factor=1000000,threads=1` will set `stress_factor` to 1000000,
+and `threads` to 1.
+
+Some OpenJDK options are also forwarded to MMTk options.
 
 -   `-XX:ParallelGCThreads=n` (where `n` is a number) sets the number of GC worker threads.
     -   MMTk option: `Options::threads`
+    -   Note that OpenJDK also has an option `-XX:ConcGCThreads`.  As we have not added any
+        concurrent GC plans into mmtk-core yet, that option is ignored when using MMTk.
 -   `-XX:+UseTransparentHugePages` enables transparent huge pages.
     -   MMTk option: `Options::transparent_hugepages`
-
-You can also set MMTk options using `-XX:ThirdPartyHeapOptions=options`, where `options` is
-`key=value` pairs separated by commas (`,`).  For example, `stress_factor=1000000,threads=1` will
-set `stress_factor` to 1000000, and `threads` to 1.
 
 Options set via command line arguments take prioritiy over environment variables starting with
 `MMTK_`.  If both the environment variable `MMTK_THREADS=1` and the command line argument

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -197,22 +197,22 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "enum-map"
-version = "2.6.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9705d8de4776df900a4a0b2384f8b0ab42f775e93b083b42f8ce71bdc32a47e3"
+checksum = "c188012f8542dee7b3996e44dd89461d64aa471b0a7c71a1ae2f595d259e96e5"
 dependencies = [
  "enum-map-derive",
 ]
 
 [[package]]
 name = "enum-map-derive"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb14d927583dd5c2eac0f2cf264fc4762aefe1ae14c47a8a20fc1939d3a5fc0"
+checksum = "04d0b288e3bb1d861c4403c1774a6f7a798781dfc519b3647df2a3dd4ae95f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -349,9 +349,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libgit2-sys"
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -401,9 +401,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.19.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=61d20e2dcd5b4743ef04a8118eb807bcd6f6e2e2#61d20e2dcd5b4743ef04a8118eb807bcd6f6e2e2"
+source = "git+https://github.com/wks/mmtk-core.git?branch=feature/no-env-var-opts#a03dc403e86d21d65bf7a02b2288731c54d71a97"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -451,12 +451,12 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.19.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=61d20e2dcd5b4743ef04a8118eb807bcd6f6e2e2#61d20e2dcd5b4743ef04a8118eb807bcd6f6e2e2"
+source = "git+https://github.com/wks/mmtk-core.git?branch=feature/no-env-var-opts#a03dc403e86d21d65bf7a02b2288731c54d71a97"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -512,10 +512,11 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
+checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
 dependencies = [
+ "memchr",
  "thiserror",
  "ucd-trie",
 ]
@@ -604,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -616,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -627,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustc_version"
@@ -642,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -694,22 +695,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -759,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -770,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.8"
+version = "0.29.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10ed79c22663a35a255d289a7fdcb43559fc77ff15df5ce6c341809e7867528"
+checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -794,22 +795,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -850,9 +851,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -865,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
 dependencies = [
  "memchr",
 ]
@@ -212,7 +212,7 @@ checksum = "04d0b288e3bb1d861c4403c1774a6f7a798781dfc519b3647df2a3dd4ae95f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -292,9 +292,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "humantime"
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.19.0"
-source = "git+https://github.com/wks/mmtk-core.git?branch=feature/no-env-var-opts#a03dc403e86d21d65bf7a02b2288731c54d71a97"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=15e19a1afa9de3403bd9f1405e4aaa78f7d1a68d#15e19a1afa9de3403bd9f1405e4aaa78f7d1a68d"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -451,12 +451,12 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.19.0"
-source = "git+https://github.com/wks/mmtk-core.git?branch=feature/no-env-var-opts#a03dc403e86d21d65bf7a02b2288731c54d71a97"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=15e19a1afa9de3403bd9f1405e4aaa78f7d1a68d#15e19a1afa9de3403bd9f1405e4aaa78f7d1a68d"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -710,7 +710,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -810,7 +810,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -30,7 +30,8 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "61d20e2dcd5b4743ef04a8118eb807bcd6f6e2e2" }
+#mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "61d20e2dcd5b4743ef04a8118eb807bcd6f6e2e2" }
+mmtk = { git = "https://github.com/wks/mmtk-core.git", branch = "feature/no-env-var-opts" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -30,8 +30,7 @@ once_cell = "1.10.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-#mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "61d20e2dcd5b4743ef04a8118eb807bcd6f6e2e2" }
-mmtk = { git = "https://github.com/wks/mmtk-core.git", branch = "feature/no-env-var-opts" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "15e19a1afa9de3403bd9f1405e4aaa78f7d1a68d" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -290,6 +290,12 @@ pub extern "C" fn process(name: *const c_char, value: *const c_char) -> bool {
     )
 }
 
+#[no_mangle]
+pub extern "C" fn mmtk_builder_read_env_var_settings() {
+    let mut builder = BUILDER.lock().unwrap();
+    builder.options.read_env_var_settings();
+}
+
 /// Pass hotspot `ParallelGCThreads` flag to mmtk
 #[no_mangle]
 pub extern "C" fn mmtk_builder_set_threads(value: usize) {

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -157,7 +157,7 @@ use std::sync::atomic::Ordering;
 pub static MMTK_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 lazy_static! {
-    pub static ref BUILDER: Mutex<MMTKBuilder> = Mutex::new(MMTKBuilder::new());
+    pub static ref BUILDER: Mutex<MMTKBuilder> = Mutex::new(MMTKBuilder::new_no_env_vars());
     pub static ref SINGLETON: MMTK<OpenJDK> = {
         let builder = BUILDER.lock().unwrap();
         assert!(!MMTK_INITIALIZED.load(Ordering::Relaxed));

--- a/openjdk/mmtk.h
+++ b/openjdk/mmtk.h
@@ -211,6 +211,7 @@ extern void add_phantom_candidate(void* ref, void* referent);
 extern void mmtk_harness_begin_impl();
 extern void mmtk_harness_end_impl();
 
+extern void mmtk_builder_read_env_var_settings();
 extern void mmtk_builder_set_threads(size_t value);
 extern void mmtk_builder_set_transparent_hugepages(bool value);
 

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -90,6 +90,10 @@ jint MMTkHeap::initialize() {
     bool set_options = process_bulk(strdup(ThirdPartyHeapOptions));
     guarantee(set_options, "Failed to set MMTk options. Please check if the options are valid: %s\n", ThirdPartyHeapOptions);
   }
+
+  // Read MMTk options from environment variables (such as `MMTK_THREADS`), overriding cmdline options.
+  mmtk_builder_read_env_var_settings();
+
   // Set heap size
   bool set_heap_size = mmtk_set_heap_size(min_heap_size, max_heap_size);
   guarantee(set_heap_size, "Failed to set MMTk heap size. Please check if the heap size is valid: min = %ld, max = %ld\n", min_heap_size, max_heap_size);

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -85,6 +85,7 @@ jint MMTkHeap::initialize() {
 
   // Read MMTk options from environment variables (such as `MMTK_THREADS`).
   // i.e. Environment variable options (priority 3) override OpenJDK's default options (priority 2).
+  // See thirdPartyHeapArguments.cpp for a list of priorities.
   mmtk_builder_read_env_var_settings();
 
   // Pass non-default OpenJDK options (may be set from command line) to MMTk options.

--- a/openjdk/mmtkHeap.hpp
+++ b/openjdk/mmtkHeap.hpp
@@ -162,6 +162,8 @@ private:
 
   void initialize_serviceability() ;
 
+  void set_mmtk_options(bool set_defaults);
+
 public:
 
   // Print heap information on the given outputStream.

--- a/openjdk/thirdPartyHeapArguments.cpp
+++ b/openjdk/thirdPartyHeapArguments.cpp
@@ -51,6 +51,14 @@ void ThirdPartyHeapArguments::initialize() {
     vm_exit_during_initialization("The flag -XX:+UseUseThirdPartyHeap can not be combined with -XX:ParallelGCThreads=0", NULL);
   }
 
+  // Note that MMTk options may be set from several different sources, with increasing priorities:
+  // 1. Default values defined in mmtk::util::options::Options
+  // 2. Default values defined in this function
+  // 3. Environment variables starting with `MMTK_`
+  // 4. Command line arguments
+  // We need to be careful about the order in which we set the options in the MMTKBuilder so that
+  // the values from the highest priority source will take effect.
+
   // Set options in MMTKBuilder to OpenJDK's default options.
   // i.e. OpenJDK's default options (priority 2) override MMTk's default options (priority 1).
   mmtk_builder_set_threads(ParallelGCThreads);

--- a/openjdk/thirdPartyHeapArguments.cpp
+++ b/openjdk/thirdPartyHeapArguments.cpp
@@ -50,19 +50,8 @@ void ThirdPartyHeapArguments::initialize() {
     assert(!FLAG_IS_DEFAULT(ParallelGCThreads), "ParallelGCThreads should not be 0.");
     vm_exit_during_initialization("The flag -XX:+UseUseThirdPartyHeap can not be combined with -XX:ParallelGCThreads=0", NULL);
   }
-
-  // Note that MMTk options may be set from several different sources, with increasing priorities:
-  // 1. Default values defined in mmtk::util::options::Options
-  // 2. Default values defined in this function
-  // 3. Environment variables starting with `MMTK_`
-  // 4. Command line arguments
-  // We need to be careful about the order in which we set the options in the MMTKBuilder so that
-  // the values from the highest priority source will take effect.
-
-  // Set options in MMTKBuilder to OpenJDK's default options.
-  // i.e. OpenJDK's default options (priority 2) override MMTk's default options (priority 1).
-  mmtk_builder_set_threads(ParallelGCThreads);
-  mmtk_builder_set_transparent_hugepages(UseTransparentHugePages);
+  // Note: If you add an option here that may be forwarded to an MMTk option,
+  // make sure to add appropriate code to MMTkHeap::set_mmtk_options.
 }
 
 CollectedHeap* ThirdPartyHeapArguments::create_heap() {

--- a/openjdk/thirdPartyHeapArguments.cpp
+++ b/openjdk/thirdPartyHeapArguments.cpp
@@ -50,7 +50,11 @@ void ThirdPartyHeapArguments::initialize() {
     assert(!FLAG_IS_DEFAULT(ParallelGCThreads), "ParallelGCThreads should not be 0.");
     vm_exit_during_initialization("The flag -XX:+UseUseThirdPartyHeap can not be combined with -XX:ParallelGCThreads=0", NULL);
   }
-  
+
+  // Set options in MMTKBuilder to OpenJDK's default options.
+  // i.e. OpenJDK's default options (priority 2) override MMTk's default options (priority 1).
+  mmtk_builder_set_threads(ParallelGCThreads);
+  mmtk_builder_set_transparent_hugepages(UseTransparentHugePages);
 }
 
 CollectedHeap* ThirdPartyHeapArguments::create_heap() {


### PR DESCRIPTION
This PR lets MMTk-side Options read environment variables for options after OpenJDK-side options are applied.  By doing this, environment variables like MMTK_THREADS are no longer ignored.

Fixes: https://github.com/mmtk/mmtk-openjdk/issues/242

This PR makes use of the change introduced in https://github.com/mmtk/mmtk-core/pull/955
