### PR TITLE
Add Java-specific constants from MMTk

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.21.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=39d237189fdfa22873eeb529f3e97b7578d9b246#39d237189fdfa22873eeb529f3e97b7578d9b246"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=28bc5130feca058147c013f6629e0cdcf15e6e58#28bc5130feca058147c013f6629e0cdcf15e6e58"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.21.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=39d237189fdfa22873eeb529f3e97b7578d9b246#39d237189fdfa22873eeb529f3e97b7578d9b246"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=28bc5130feca058147c013f6629e0cdcf15e6e58#28bc5130feca058147c013f6629e0cdcf15e6e58"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.21.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=28bc5130feca058147c013f6629e0cdcf15e6e58#28bc5130feca058147c013f6629e0cdcf15e6e58"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=b06619982f3cee271e453a555f48b613f3eba2f6#b06619982f3cee271e453a555f48b613f3eba2f6"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.21.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=28bc5130feca058147c013f6629e0cdcf15e6e58#28bc5130feca058147c013f6629e0cdcf15e6e58"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=b06619982f3cee271e453a555f48b613f3eba2f6#b06619982f3cee271e453a555f48b613f3eba2f6"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -32,7 +32,7 @@ memoffset = "0.9.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "28bc5130feca058147c013f6629e0cdcf15e6e58" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "b06619982f3cee271e453a555f48b613f3eba2f6" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -32,7 +32,7 @@ memoffset = "0.9.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "39d237189fdfa22873eeb529f3e97b7578d9b246" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "28bc5130feca058147c013f6629e0cdcf15e6e58" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/abi.rs
+++ b/mmtk/src/abi.rs
@@ -11,6 +11,17 @@ use std::fmt;
 use std::sync::atomic::AtomicUsize;
 use std::{mem, slice};
 
+// These are some Java specific constants that were in MMTk.
+// As we plan to remove them from MMTk, they are moved here.
+// We could further investigae if we really need them in the OpenJDK binding.
+
+pub const LOG_BYTES_IN_INT: u8 = 2;
+pub const BYTES_IN_INT: usize = 1 << LOG_BYTES_IN_INT;
+pub const LOG_BYTES_IN_LONG: u8 = 3;
+pub const BYTES_IN_LONG: usize = 1 << LOG_BYTES_IN_LONG;
+pub const LOG_BITS_IN_LONG: u8 = LOG_BITS_IN_BYTE + LOG_BYTES_IN_LONG;
+pub const BITS_IN_LONG: usize = 1 << LOG_BITS_IN_LONG;
+
 #[repr(i32)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[allow(dead_code)]

--- a/mmtk/src/edges.rs
+++ b/mmtk/src/edges.rs
@@ -6,10 +6,7 @@ use std::{
 use super::abi::LOG_BYTES_IN_INT;
 use atomic::Atomic;
 use mmtk::{
-    util::{
-        constants::LOG_BYTES_IN_WORD,
-        Address, ObjectReference,
-    },
+    util::{constants::LOG_BYTES_IN_WORD, Address, ObjectReference},
     vm::edge_shape::{Edge, MemorySlice},
 };
 

--- a/mmtk/src/edges.rs
+++ b/mmtk/src/edges.rs
@@ -3,10 +3,11 @@ use std::{
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
+use super::abi::LOG_BYTES_IN_INT;
 use atomic::Atomic;
 use mmtk::{
     util::{
-        constants::{LOG_BYTES_IN_INT, LOG_BYTES_IN_WORD},
+        constants::LOG_BYTES_IN_WORD,
         Address, ObjectReference,
     },
     vm::edge_shape::{Edge, MemorySlice},


### PR DESCRIPTION
Java-specific constants in MMTk are no longer public in https://github.com/mmtk/mmtk-core/pull/1026. This PR duplicates the constants that are used in the binding.