### PR TITLE
Add option to put forwarding bits on the side

### DIFF
--- a/.github/scripts/ci-test-forwarding-on-side.sh
+++ b/.github/scripts/ci-test-forwarding-on-side.sh
@@ -1,0 +1,21 @@
+set -xe
+
+. $(dirname "$0")/common.sh
+
+unset JAVA_TOOL_OPTIONS
+
+run_subset() {
+    heap_multiplier=$1
+
+    runbms_dacapo2006_with_heap_multiplier antlr $heap_multiplier
+    runbms_dacapo2006_with_heap_multiplier fop $heap_multiplier
+    runbms_dacapo2006_with_heap_multiplier luindex $heap_multiplier
+    runbms_dacapo2006_with_heap_multiplier lusearch $heap_multiplier
+}
+
+# Run plans that involve CopySpace and ImmixSpace which use forwarding bits.
+MMTK_PLAN=SemiSpace run_subset 4
+MMTK_PLAN=Immix run_subset 4
+MMTK_PLAN=GenCopy run_subset 4
+MMTK_PLAN=GenImmix run_subset 4
+MMTK_PLAN=StickyImmix run_subset 4

--- a/.github/scripts/ci-test-minimal.sh
+++ b/.github/scripts/ci-test-minimal.sh
@@ -38,6 +38,8 @@ MMTK_PLAN=GenImmix runbms_dacapo2006_with_heap_multiplier fop 4
 # Build with on-the-side forwarding bits
 MMTK_FORWARDING_ON_SIDE=1 $cur/ci-build.sh
 # Test
-MMTK_PLAN=SemiSpace runbms_dacapo2006_with_heap_multiplier fop 4
-MMTK_PLAN=GenImmix runbms_dacapo2006_with_heap_multiplier fop 4
-MMTK_PLAN=StickyImmix runbms_dacapo2006_with_heap_multiplier fop 4
+MMTK_PLAN=SemiSpace runbms_dacapo2006_with_heap_multiplier lusearch 4
+MMTK_PLAN=Immix runbms_dacapo2006_with_heap_multiplier lusearch 4
+MMTK_PLAN=GenCopy runbms_dacapo2006_with_heap_multiplier lusearch 4
+MMTK_PLAN=GenImmix runbms_dacapo2006_with_heap_multiplier lusearch 4
+MMTK_PLAN=StickyImmix runbms_dacapo2006_with_heap_multiplier lusearch 4

--- a/.github/scripts/ci-test-minimal.sh
+++ b/.github/scripts/ci-test-minimal.sh
@@ -34,3 +34,10 @@ MMTK_PLAN=GenImmix runbms_dacapo2006_with_heap_multiplier fop 4 -XX:-UseCompress
 MMTK_VO_BIT=1 $cur/ci-build.sh
 # Test
 MMTK_PLAN=GenImmix runbms_dacapo2006_with_heap_multiplier fop 4
+
+# Build with on-the-side forwarding bits
+MMTK_FORWARDING_ON_SIDE=1 $cur/ci-build.sh
+# Test
+MMTK_PLAN=SemiSpace runbms_dacapo2006_with_heap_multiplier fop 4
+MMTK_PLAN=GenImmix runbms_dacapo2006_with_heap_multiplier fop 4
+MMTK_PLAN=StickyImmix runbms_dacapo2006_with_heap_multiplier fop 4

--- a/.github/workflows/run-dacapo-2006.yml
+++ b/.github/workflows/run-dacapo-2006.yml
@@ -89,7 +89,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-script: ["ci-test-vo-bit", "ci-test-assertions", "ci-test-malloc-mark-sweep", "ci-test-mark-in-header"]
+        test-script:
+          - ci-test-vo-bit
+          - ci-test-assertions
+          - ci-test-malloc-mark-sweep
+          - ci-test-mark-in-header
+          - ci-test-forwarding-on-side
         include:
           - test-script: ci-test-vo-bit
             build-suffix: MMTK_VO_BIT=1
@@ -99,6 +104,8 @@ jobs:
             build-suffix: MMTK_MALLOC_MARK_SWEEP=1_MMTK_EXTREME_ASSERTIONS=1
           - test-script: ci-test-mark-in-header
             build-suffix: MMTK_MALLOC_MARK_SWEEP=1_MMTK_MARK_IN_HEADER=1
+          - test-script: ci-test-forwarding-on-side
+            build-suffix: MMTK_FORWARDING_ON_SIDE=1
     steps:
       - name: Checkout MMTk OpenJDK binding
         uses: actions/checkout@v4

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -48,6 +48,12 @@ jobs:
       build-env-var: MMTK_MALLOC_MARK_SWEEP=1 MMTK_MARK_IN_HEADER=1
       debug-level: fastdebug
 
+  build-forwarding-on-side:
+    uses: ./.github/workflows/build.yml
+    with:
+      build-env-var: MMTK_FORWARDING_ON_SIDE=1
+      debug-level: fastdebug
+
   run-dacapo-2006:
     needs:
       - build-normal-fastdebug
@@ -55,6 +61,7 @@ jobs:
       - build-extreme-assertions
       - build-malloc-mark-sweep
       - build-mark-in-header
+      - build-forwarding-on-side
     uses: ./.github/workflows/run-dacapo-2006.yml
 
   run-dacapo-chopin:

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -432,6 +432,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.25.0"
+source = "git+https://github.com/wks/mmtk-core.git?rev=899856d394ebf5fe47c560e155caac634276cfff#899856d394ebf5fe47c560e155caac634276cfff"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -466,11 +467,12 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.25.0"
+source = "git+https://github.com/wks/mmtk-core.git?rev=899856d394ebf5fe47c560e155caac634276cfff#899856d394ebf5fe47c560e155caac634276cfff"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -479,6 +481,7 @@ version = "0.25.0"
 dependencies = [
  "atomic",
  "built",
+ "cfg-if",
  "lazy_static",
  "libc",
  "memoffset",
@@ -693,7 +696,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -708,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.25.0"
-source = "git+https://github.com/wks/mmtk-core.git?rev=805b3b8dee8053d0b0574234095348acb89c216f#805b3b8dee8053d0b0574234095348acb89c216f"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=a9b619a4ee18a4f83209f930f8c48a3b63ee478c#a9b619a4ee18a4f83209f930f8c48a3b63ee478c"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.25.0"
-source = "git+https://github.com/wks/mmtk-core.git?rev=805b3b8dee8053d0b0574234095348acb89c216f#805b3b8dee8053d0b0574234095348acb89c216f"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=a9b619a4ee18a4f83209f930f8c48a3b63ee478c#a9b619a4ee18a4f83209f930f8c48a3b63ee478c"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.25.0"
-source = "git+https://github.com/wks/mmtk-core.git?rev=899856d394ebf5fe47c560e155caac634276cfff#899856d394ebf5fe47c560e155caac634276cfff"
+source = "git+https://github.com/wks/mmtk-core.git?rev=805b3b8dee8053d0b0574234095348acb89c216f#805b3b8dee8053d0b0574234095348acb89c216f"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.25.0"
-source = "git+https://github.com/wks/mmtk-core.git?rev=899856d394ebf5fe47c560e155caac634276cfff#899856d394ebf5fe47c560e155caac634276cfff"
+source = "git+https://github.com/wks/mmtk-core.git?rev=805b3b8dee8053d0b0574234095348acb89c216f#805b3b8dee8053d0b0574234095348acb89c216f"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -425,7 +425,6 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.25.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=dccce9063b57dde96d2e97670297aed4dc32e6e1#dccce9063b57dde96d2e97670297aed4dc32e6e1"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -460,7 +459,6 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.25.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=dccce9063b57dde96d2e97670297aed4dc32e6e1#dccce9063b57dde96d2e97670297aed4dc32e6e1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -26,16 +26,17 @@ lazy_static = "1.1"
 once_cell = "1.10.0"
 atomic = "0.6.0"
 memoffset = "0.9.0"
+cfg-if = "1.0"
+
 # Be very careful to commit any changes to the following mmtk dependency, as our CI scripts (including mmtk-core CI)
 # rely on matching these lines to modify them: e.g. comment out the git dependency and use the local path.
 # These changes are safe:
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-#mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "56b2521d2b99848ee0613a0a5288fe6d81b754ba" }
+mmtk = { git = "https://github.com/wks/mmtk-core.git", rev = "899856d394ebf5fe47c560e155caac634276cfff" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
-mmtk = { path = "../../mmtk-core" }
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2"] }
@@ -49,8 +50,11 @@ nogc_no_zeroing = ["mmtk/nogc_no_zeroing"]
 # See README.
 vo_bit = ["mmtk/vo_bit"]
 
-# This compile time constant places the mark bit in the header of the object instead of on the side.
+# Place the mark bit in the header of objects instead of on the side.
 mark_bit_in_header = []
+
+# Place the forwarding bits on the side instead of in the header of objects.
+forwarding_bits_on_side = []
 
 # Use malloc mark sweep - we should only run marksweep with this feature turned on.
 malloc_mark_sweep = ["mmtk/malloc_mark_sweep"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -34,7 +34,7 @@ cfg-if = "1.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/wks/mmtk-core.git", rev = "805b3b8dee8053d0b0574234095348acb89c216f" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "a9b619a4ee18a4f83209f930f8c48a3b63ee478c" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -34,7 +34,7 @@ cfg-if = "1.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/wks/mmtk-core.git", rev = "899856d394ebf5fe47c560e155caac634276cfff" }
+mmtk = { git = "https://github.com/wks/mmtk-core.git", rev = "805b3b8dee8053d0b0574234095348acb89c216f" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -32,9 +32,10 @@ memoffset = "0.9.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "dccce9063b57dde96d2e97670297aed4dc32e6e1" }
+#mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "dccce9063b57dde96d2e97670297aed4dc32e6e1" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
+mmtk = { path = "../../mmtk-core" }
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2"] }

--- a/mmtk/src/vm_metadata/constants.rs
+++ b/mmtk/src/vm_metadata/constants.rs
@@ -25,7 +25,7 @@ pub(crate) const FORWARDING_POINTER_METADATA_SPEC: VMLocalForwardingPointerSpec 
 /// PolicySpecific object forwarding status metadata spec
 /// 2 bits per object
 pub(crate) const FORWARDING_BITS_METADATA_SPEC: VMLocalForwardingBitsSpec =
-    VMLocalForwardingBitsSpec::in_header(FORWARDING_BITS_OFFSET);
+    VMLocalForwardingBitsSpec::side_after(MARKING_METADATA_SPEC.as_spec());
 
 /// PolicySpecific mark bit metadata spec
 /// 1 bit per object

--- a/mmtk/src/vm_metadata/constants.rs
+++ b/mmtk/src/vm_metadata/constants.rs
@@ -1,8 +1,10 @@
-use mmtk::vm::*;
+use mmtk::{util::metadata::MetadataSpec, vm::*};
 
 #[cfg(target_pointer_width = "64")]
+#[allow(unused)]
 pub(crate) const FORWARDING_BITS_OFFSET: isize = 56;
 #[cfg(target_pointer_width = "32")]
+#[allow(unused)]
 pub(crate) const FORWARDING_BITS_OFFSET: isize = unimplemented!();
 
 pub(crate) const FORWARDING_POINTER_OFFSET: isize = 0;
@@ -22,20 +24,39 @@ pub(crate) const LOGGING_SIDE_METADATA_SPEC: VMGlobalLogBitSpec = VMGlobalLogBit
 pub(crate) const FORWARDING_POINTER_METADATA_SPEC: VMLocalForwardingPointerSpec =
     VMLocalForwardingPointerSpec::in_header(FORWARDING_POINTER_OFFSET);
 
-/// PolicySpecific object forwarding status metadata spec
-/// 2 bits per object
-pub(crate) const FORWARDING_BITS_METADATA_SPEC: VMLocalForwardingBitsSpec =
-    VMLocalForwardingBitsSpec::side_after(MARKING_METADATA_SPEC.as_spec());
+cfg_if::cfg_if! {
+    if #[cfg(feature = "mark_bit_in_header")] {
+        /// PolicySpecific mark bit metadata spec
+        /// 1 bit per object
+        pub(crate) const MARKING_METADATA_SPEC: VMLocalMarkBitSpec =
+            VMLocalMarkBitSpec::in_header(FORWARDING_BITS_OFFSET);
 
-/// PolicySpecific mark bit metadata spec
-/// 1 bit per object
-#[cfg(feature = "mark_bit_in_header")]
-pub(crate) const MARKING_METADATA_SPEC: VMLocalMarkBitSpec =
-    VMLocalMarkBitSpec::in_header(FORWARDING_BITS_OFFSET);
+        #[allow(unused)]
+        const LAST_SIDE_SPEC_BEFORE_MARK: &MetadataSpec = LOS_METADATA_SPEC.as_spec();
+    } else {
+        /// PolicySpecific mark bit metadata spec
+        /// 1 bit per object
+        pub(crate) const MARKING_METADATA_SPEC: VMLocalMarkBitSpec =
+            VMLocalMarkBitSpec::side_after(LOS_METADATA_SPEC.as_spec());
 
-#[cfg(not(feature = "mark_bit_in_header"))]
-pub(crate) const MARKING_METADATA_SPEC: VMLocalMarkBitSpec =
-    VMLocalMarkBitSpec::side_after(LOS_METADATA_SPEC.as_spec());
+        #[allow(unused)]
+        const LAST_SIDE_SPEC_BEFORE_MARK: &MetadataSpec = MARKING_METADATA_SPEC.as_spec();
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "forwarding_bits_on_side")] {
+        /// PolicySpecific object forwarding status metadata spec
+        /// 2 bits per object
+        pub(crate) const FORWARDING_BITS_METADATA_SPEC: VMLocalForwardingBitsSpec =
+            VMLocalForwardingBitsSpec::side_after(LAST_SIDE_SPEC_BEFORE_MARK);
+    } else {
+        /// PolicySpecific object forwarding status metadata spec
+        /// 2 bits per object
+        pub(crate) const FORWARDING_BITS_METADATA_SPEC: VMLocalForwardingBitsSpec =
+            VMLocalForwardingBitsSpec::in_header(FORWARDING_BITS_OFFSET);
+    }
+}
 
 /// PolicySpecific mark-and-nursery bits metadata spec
 /// 2-bits per object

--- a/openjdk/CompileThirdPartyHeap.gmk
+++ b/openjdk/CompileThirdPartyHeap.gmk
@@ -35,6 +35,14 @@ ifeq ($(MMTK_MARK_IN_HEADER), 1)
   endif
 endif
 
+ifeq ($(MMTK_FORWARDING_ON_SIDE), 1)
+  ifndef GC_FEATURES
+    GC_FEATURES=--features forwarding_bits_on_side
+  else
+    GC_FEATURES:=$(strip $(GC_FEATURES))",forwarding_bits_on_side"
+  endif
+endif
+
 ifeq ($(MMTK_EXTREME_ASSERTIONS), 1)
   ifndef GC_FEATURES
     GC_FEATURES=--features mmtk_extreme_assertions


### PR DESCRIPTION
Added a feature to force using on-the-side forwarding bits.  This is for testing mmtk-core.  The CI script for minimal test is also extended to run several plans involving CopySpace and ImmixSpace on OpenJDK with side forwarding bits.

Related PR: https://github.com/mmtk/mmtk-core/pull/1138 The feature introduced in this PR can be used to check the correctness of that PR.