### PR TITLE
Fix deadlock related to safepoint sync.

### DIFF
--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -69,7 +69,7 @@ MMTkHeap::MMTkHeap(MMTkCollectorPolicy* policy) :
   _collector_policy(policy),
   _num_root_scan_tasks(0),
   _n_workers(0),
-  _gc_lock(new Monitor(Mutex::safepoint, "MMTkHeap::_gc_lock", true, Monitor::_safepoint_check_sometimes)),
+  _gc_lock(new Monitor(Mutex::safepoint, "MMTkHeap::_gc_lock", true, Monitor::_safepoint_check_never)),
   _soft_ref_policy()
 {
   _heap = this;

--- a/openjdk/mmtkVMCompanionThread.cpp
+++ b/openjdk/mmtkVMCompanionThread.cpp
@@ -53,7 +53,7 @@ void MMTkVMCompanionThread::run() {
       MutexLockerEx locker(_lock, Mutex::_no_safepoint_check_flag);
       assert(_reached_state == _threads_resumed, "Threads should be running at this moment.");
       while (_desired_state != _threads_suspended) {
-        _lock->wait(true);
+        _lock->wait(Mutex::_no_safepoint_check_flag);
       }
       assert(_reached_state == _threads_resumed, "Threads should still be running at this moment.");
     }
@@ -63,25 +63,9 @@ void MMTkVMCompanionThread::run() {
     VM_MMTkSTWOperation op(this);
     // VMThread::execute() is blocking. The companion thread will be blocked
     // here waiting for the VM thread to execute op, and the VM thread will
-    // be blocked in reach_suspended_and_wait_for_resume() until a GC thread
+    // be blocked in do_mmtk_stw_operation() until a GC thread
     // calls request(_threads_resumed).
     VMThread::execute(&op);
-
-    // Tell the waiter thread that the world has resumed.
-    log_trace(gc)("MMTkVMCompanionThread: Notifying threads resumption...");
-    {
-      MutexLockerEx locker(_lock, Mutex::_no_safepoint_check_flag);
-      assert(_desired_state == _threads_resumed, "start-the-world should be requested.");
-      assert(_reached_state == _threads_suspended, "Threads should still be suspended at this moment.");
-      _reached_state = _threads_resumed;
-      _lock->notify_all();
-    }
-    {
-      MutexLocker x(Heap_lock);
-      if (Universe::has_reference_pending_list()) {
-        Heap_lock->notify_all();
-      }
-    }
   }
 }
 
@@ -107,7 +91,7 @@ void MMTkVMCompanionThread::request(stw_state desired_state, bool wait_until_rea
 
   if (wait_until_reached) {
     while (_reached_state != desired_state) {
-      _lock->wait(true);
+      _lock->wait(Mutex::_no_safepoint_check_flag);
     }
   }
 }
@@ -123,23 +107,70 @@ void MMTkVMCompanionThread::wait_for_reached(stw_state desired_state) {
   assert(_desired_state == desired_state, "State %d not requested.", desired_state);
 
   while (_reached_state != desired_state) {
-    _lock->wait(true);
+    _lock->wait(Mutex::_no_safepoint_check_flag);
   }
 }
 
-// Called by the VM thread to indicate that all Java threads have stopped.
-// This method will block until the GC requests start-the-world.
-void MMTkVMCompanionThread::reach_suspended_and_wait_for_resume() {
-  assert(Thread::current()->is_VM_thread(), "reach_suspended_and_wait_for_resume can only be executed by the VM thread");
+// Called by the VM thread in `VM_MMTkSTWOperation`.
+// This method notify that all Java threads have yielded, and will block the VM thread (thereby
+// blocking Java threads) until the GC requests start-the-world.
+void MMTkVMCompanionThread::do_mmtk_stw_operation() {
+  assert(Thread::current()->is_VM_thread(), "do_mmtk_stw_operation can only be executed by the VM thread");
 
-  MutexLockerEx locker(_lock, Mutex::_no_safepoint_check_flag);
+  {
+    MutexLockerEx locker(_lock, Mutex::_no_safepoint_check_flag);
 
-  // Tell the waiter thread that the world has stopped.
-  _reached_state = _threads_suspended;
-  _lock->notify_all();
+    // Tell the waiter thread that Java threads have stopped at yieldpoints.
+    _reached_state = _threads_suspended;
+    log_trace(gc)("do_mmtk_stw_operation: Reached _thread_suspended state. Notifying...");
+    _lock->notify_all();
 
-  // Wait until resume-the-world is requested
-  while (_desired_state != _threads_resumed) {
-    _lock->wait(true);
+    // Wait until resume-the-world is requested
+    while (_desired_state != _threads_resumed) {
+      _lock->wait(Mutex::_no_safepoint_check_flag);
+    }
+
+    // Tell the waiter thread that Java threads will eventually resume from yieldpoints.  This
+    // function will return, and, as soon as the VM thread stops executing safepoint VM operations,
+    // Java threads will resume from yieldpoints.
+    //
+    // Note: We have to notify *now* instead of after `VMThread::execute()`.  For reasons unknown
+    // (likely a bug in OpenJDK 11), the VMThread fails to notify the companion thread after
+    // evaluating `VM_MMTkSTWOperation`, and continues to execute other VM operations (such as
+    // `RevokeBias`). This leaves the companion thread blocking on `VMThread::execute()` until the
+    // VM thread finishes executing the next batch of queued VM operations.  If we notify after
+    // `VMThread::execute` in `run()`, it will cause a deadlock like the following:
+    //
+    // - The companion thread is blocked at `VMThread::execute()`, waiting for the next batch of VM
+    //   operations to finish.
+    // - The VM thread is blocked in `SafepointSynchronize::begin()`, waiting for all mutators to
+    //   reach safepoints.
+    // - One mutator is allocating too fast and triggers a GC, which requires the `WorkerMonitor`
+    //   lock in mmtk-core.
+    // - A GC worker is still executing `mmtk_resume_mutator`, holding the `WorkerMutator` (as the
+    //   last parked GC worker).  It is asking the companion thread to resume mutators, and is still
+    //   waiting for the companion thread to reach the `_thread_resumed` state.  As we see before,
+    //   the companion thread is waiting, too.
+    //
+    // By notifying now, we let the companion thread stop waiting, and therefore allowing the last
+    // parked GC worker to finish `resume_mutators`, breaking the deadlock.  When the next GC
+    // starts, the GC worker running `mmtk_stop_all_mutators` will need to wait a little longer (as
+    // it always should) until the VM thread finishes executing other VM operations and the
+    // companion thread is ready to respond to another request from GC workers.
+    //
+    // Also note that OpenJDK 17 changed the way the VM thread executes VM operations.  The same
+    // problem may not manifest in OpenJDK 17 or 21.
+    assert(_desired_state == _threads_resumed, "start-the-world should be requested.");
+    assert(_reached_state == _threads_suspended, "Threads should still be suspended at this moment.");
+    _reached_state = _threads_resumed;
+    log_trace(gc)("do_mmtk_stw_operation: Reached _thread_resumed state. Notifying...");
+    _lock->notify_all();
+  }
+
+  {
+    MutexLockerEx x(Heap_lock, Mutex::_no_safepoint_check_flag);
+    if (Universe::has_reference_pending_list()) {
+      Heap_lock->notify_all();
+    }
   }
 }

--- a/openjdk/mmtkVMCompanionThread.hpp
+++ b/openjdk/mmtkVMCompanionThread.hpp
@@ -63,7 +63,7 @@ public:
   void wait_for_reached(stw_state reached_state);
 
   // Interface for the VM_MMTkSTWOperation
-  void reach_suspended_and_wait_for_resume();
+  void do_mmtk_stw_operation();
 };
 
 #endif // MMTK_OPENJDK_MMTK_VM_COMPANION_THREAD_HPP

--- a/openjdk/mmtkVMOperation.cpp
+++ b/openjdk/mmtkVMOperation.cpp
@@ -34,6 +34,6 @@ VM_MMTkSTWOperation::VM_MMTkSTWOperation(MMTkVMCompanionThread *companion_thread
 
 void VM_MMTkSTWOperation::doit() {
     log_trace(vmthread)("Entered VM_MMTkSTWOperation::doit().");
-    _companion_thread->reach_suspended_and_wait_for_resume();
+    _companion_thread->do_mmtk_stw_operation();
     log_trace(vmthread)("Leaving VM_MMTkSTWOperation::doit()");
 }


### PR DESCRIPTION
`gc_lock` now never does safepoint check.  We always explicitly enter safepoint via `ThreadBlockInVM`.

The VM companion thread now lets `VM_MMTkSTWOperation` (executed by the VM thread) transition the state to `_threads_resumed` instead of doing it after `VMThread::execute` returns.  This works around a problem where `VMThread::execute` continues to block the companion thread when the VM thread starts executing other VM operations.

Some minor style changes:

We consistently use the constant `Mutex::_no_safepoint_check_flag` instead of `true` when acquiring or waiting for the `Monitor`.

Slightly updated comments and logs.  Logging statements no longer include thread IDs because thread IDs can be turned on by a command line option.