### PR TITLE
Generational code cache roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ target/
 /*.so
 
 /repos/mmtk-core
+
+__pycache__

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.16"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "jobserver",
  "libc",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.27.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9#45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=a025c24104d8d456a865aa0122e6e0fb6d77e8f2#a025c24104d8d456a865aa0122e6e0fb6d77e8f2"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -474,7 +474,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.27.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9#45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=a025c24104d8d456a865aa0122e6e0fb6d77e8f2#a025c24104d8d456a865aa0122e6e0fb6d77e8f2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -494,6 +494,7 @@ dependencies = [
  "memoffset",
  "mmtk",
  "once_cell",
+ "probe",
 ]
 
 [[package]]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mmtk_openjdk"
 version = "0.27.0"
 authors = [" <>"]
-rust-version = "1.71.1"
+rust-version = "1.73.0"
 build = "build.rs"
 edition = "2021"
 
@@ -27,6 +27,7 @@ once_cell = "1.10.0"
 atomic = "0.6.0"
 memoffset = "0.9.0"
 cfg-if = "1.0"
+probe = "0.5"
 
 # Be very careful to commit any changes to the following mmtk dependency, as our CI scripts (including mmtk-core CI)
 # rely on matching these lines to modify them: e.g. comment out the git dependency and use the local path.
@@ -34,7 +35,7 @@ cfg-if = "1.0"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "a025c24104d8d456a865aa0122e6e0fb6d77e8f2" }
 # Uncomment the following to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/gc_work.rs
+++ b/mmtk/src/gc_work.rs
@@ -1,10 +1,10 @@
-use std::sync::atomic::Ordering;
-
+use crate::scanning;
 use crate::scanning::to_slots_closure;
 use crate::OpenJDK;
 use crate::OpenJDKSlot;
 use crate::UPCALLS;
 use mmtk::scheduler::*;
+use mmtk::util::Address;
 use mmtk::vm::RootsWorkFactory;
 use mmtk::vm::*;
 use mmtk::MMTK;
@@ -69,16 +69,51 @@ impl<const COMPRESSED: bool, F: RootsWorkFactory<OpenJDKSlot<COMPRESSED>>>
     fn do_work(
         &mut self,
         _worker: &mut GCWorker<OpenJDK<COMPRESSED>>,
-        _mmtk: &'static MMTK<OpenJDK<COMPRESSED>>,
+        mmtk: &'static MMTK<OpenJDK<COMPRESSED>>,
     ) {
-        // Collect all the cached roots
-        let mut slots = Vec::with_capacity(crate::CODE_CACHE_ROOTS_SIZE.load(Ordering::Relaxed));
-        for roots in (*crate::CODE_CACHE_ROOTS.lock().unwrap()).values() {
-            for r in roots {
-                slots.push((*r).into())
+        let is_current_gc_nursery = mmtk
+            .get_plan()
+            .generational()
+            .is_some_and(|gen| gen.is_current_gc_nursery());
+
+            let mut slots = Vec::with_capacity(scanning::WORK_PACKET_CAPACITY);
+
+        let mut nursery_slots = 0;
+        let mut mature_slots = 0;
+
+        let mut add_roots = |roots: &[Address]| {
+            for root in roots {
+                slots.push(OpenJDKSlot::<COMPRESSED>::from(*root));
+                if slots.len() >= scanning::WORK_PACKET_CAPACITY {
+                    self.factory
+                        .create_process_roots_work(std::mem::take(&mut slots));
+                }
+            }
+        };
+
+        {
+            let mut mature = crate::MATURE_CODE_CACHE_ROOTS.lock().unwrap();
+
+            // Only scan mature roots in full-heap collections.
+            if !is_current_gc_nursery {
+                for roots in mature.values() {
+                    mature_slots += roots.len();
+                    add_roots(roots);
+                }
+            }
+
+            {
+                let mut nursery = crate::NURSERY_CODE_CACHE_ROOTS.lock().unwrap();
+                for (key, roots) in nursery.drain() {
+                    nursery_slots += roots.len();
+                    add_roots(&roots);
+                    mature.insert(key, roots);
+                }
             }
         }
-        // Create work packet
+
+        probe!(mmtk_openjdk, code_cache_roots, nursery_slots, mature_slots);
+
         if !slots.is_empty() {
             self.factory.create_process_roots_work(slots);
         }

--- a/mmtk/src/gc_work.rs
+++ b/mmtk/src/gc_work.rs
@@ -76,7 +76,7 @@ impl<const COMPRESSED: bool, F: RootsWorkFactory<OpenJDKSlot<COMPRESSED>>>
             .generational()
             .is_some_and(|gen| gen.is_current_gc_nursery());
 
-            let mut slots = Vec::with_capacity(scanning::WORK_PACKET_CAPACITY);
+        let mut slots = Vec::with_capacity(scanning::WORK_PACKET_CAPACITY);
 
         let mut nursery_slots = 0;
         let mut mature_slots = 0;

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -1,9 +1,10 @@
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate probe;
 
 use std::collections::HashMap;
 use std::ptr::null_mut;
-use std::sync::atomic::AtomicUsize;
 use std::sync::Mutex;
 
 use libc::{c_char, c_void, uintptr_t};
@@ -202,12 +203,11 @@ pub static MMTK_MARK_COMPACT_HEADER_RESERVED_IN_BYTES: usize =
     mmtk::util::alloc::MarkCompactAllocator::<OpenJDK<false>>::HEADER_RESERVED_IN_BYTES;
 
 lazy_static! {
-    /// A global storage for all the cached CodeCache root pointers
-    static ref CODE_CACHE_ROOTS: Mutex<HashMap<Address, Vec<Address>>> = Mutex::new(HashMap::new());
+    /// A global storage for all the cached CodeCache root pointers added since the last GC.
+    static ref NURSERY_CODE_CACHE_ROOTS: Mutex<HashMap<Address, Vec<Address>>> = Mutex::new(HashMap::new());
+    /// A global storage for all the cached CodeCache root pointers added before the last GC.
+    static ref MATURE_CODE_CACHE_ROOTS: Mutex<HashMap<Address, Vec<Address>>> = Mutex::new(HashMap::new());
 }
-
-/// A counter tracking the total size of the `CODE_CACHE_ROOTS`.
-static CODE_CACHE_ROOTS_SIZE: AtomicUsize = AtomicUsize::new(0);
 
 fn set_compressed_pointer_vm_layout(builder: &mut MMTKBuilder) {
     let max_heap_size = builder.options.gc_trigger.max_heap_size();

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -203,9 +203,9 @@ pub static MMTK_MARK_COMPACT_HEADER_RESERVED_IN_BYTES: usize =
     mmtk::util::alloc::MarkCompactAllocator::<OpenJDK<false>>::HEADER_RESERVED_IN_BYTES;
 
 lazy_static! {
-    /// A global storage for all the cached CodeCache root pointers added since the last GC.
+    /// A global storage for all the cached CodeCache roots added since the last GC.
     static ref NURSERY_CODE_CACHE_ROOTS: Mutex<HashMap<Address, Vec<Address>>> = Mutex::new(HashMap::new());
-    /// A global storage for all the cached CodeCache root pointers added before the last GC.
+    /// A global storage for all the cached CodeCache roots added before the last GC.
     static ref MATURE_CODE_CACHE_ROOTS: Mutex<HashMap<Address, Vec<Address>>> = Mutex::new(HashMap::new());
 }
 

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -12,7 +12,7 @@ use mmtk::MutatorContext;
 
 pub struct VMScanning {}
 
-const WORK_PACKET_CAPACITY: usize = 4096;
+pub(crate) const WORK_PACKET_CAPACITY: usize = 4096;
 
 extern "C" fn report_slots_and_renew_buffer<S: Slot, F: RootsWorkFactory<S>>(
     ptr: *mut Address,

--- a/tools/tracing/timeline/capture_openjdk.bt
+++ b/tools/tracing/timeline/capture_openjdk.bt
@@ -1,0 +1,5 @@
+usdt:$MMTK:mmtk_openjdk:code_cache_roots {
+    if (@enable_print) {
+        printf("code_cache_roots,meta,%d,%lu,%lu,%lu\n", tid, nsecs, arg0, arg1);
+    }
+}

--- a/tools/tracing/timeline/visualize_openjdk.py
+++ b/tools/tracing/timeline/visualize_openjdk.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+def enrich_meta_extra(log_processor, name, tid, ts, gc, wp, args):
+    if wp is not None:
+        match name:
+            case "code_cache_roots":
+                nursery, mature = int(args[0]), int(args[1])
+                total = nursery + mature
+                wp["args"] |= {
+                    "nursery_slots": nursery,
+                    "mature_slots": mature,
+                    "total_slots": total,
+                }


### PR DESCRIPTION
This PR ports the generational code cache roots handling code from the LXR branch. See https://github.com/wenyuzhao/mmtk-openjdk/blob/lxr/mmtk/src/gc_work.rs#L242-L262

We split code cache roots into two hash tables, one for nursery roots and one for mature roots.  Nursery roots are those added since the previous GC.  In a nursery GC, we only scan the nursery code cache roots, assuming mature code cache roots all point to mature objects.  In a full-heap GC, we scan both nursery and mature code cache roots.

Because code cache roots are added in bulk in the beginning of execution, and are seldom added later, we expect the number of code cache roots to reduce to zero for most nursery GCs, and greatly reduce the root-scanning time.

This PR also adds USDT tracepoints for code cache roots, and make use of the extensible eBPF timeline tools in mmtk-core introduced in https://github.com/mmtk/mmtk-core/pull/1162.