### PR TITLE
Bump version of action/upload-artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         OPENJDK_PATH=$GITHUB_WORKSPACE/git/openjdk DEBUG_LEVEL=${{ inputs.debug-level }} OPENJDK_BUILD_TARGET=product-bundles ./.github/scripts/ci-build.sh
       working-directory: ./git/mmtk-openjdk
     - name: Upload bundles
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-x86_64-server-${{ inputs.debug-level }}-bundles-${{ env.BUILD_SUFFIX }}
         path: |

--- a/.github/workflows/run-dacapo-chopin.yml
+++ b/.github/workflows/run-dacapo-chopin.yml
@@ -138,7 +138,7 @@ jobs:
           RUN_ID=`sed -n 's/^Run id:.\(.*\)$/\1/p' < /tmp/running.stdout`
           echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
       - name: Upload running artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-x86_64-${{ matrix.benchmark }}-${{ matrix.debug-level }}
           path: /tmp/${{ steps.extract-running-run-id.outputs.run-id }}/


### PR DESCRIPTION
https://github.com/mmtk/mmtk-openjdk/pull/287 bumps the version of download-artifact. We need to use a compatible version for upload-artifact.