### PR TITLE
Fix compressed val register.

### DIFF
--- a/.github/scripts/ci-test-minimal.sh
+++ b/.github/scripts/ci-test-minimal.sh
@@ -27,6 +27,8 @@ MMTK_PLAN=MarkSweep runbms_dacapo2006_with_heap_multiplier fop 8
 MMTK_PLAN=NoGC runbms_dacapo2006_with_heap_size fop 1000 1000
 # Test heap resizing
 MMTK_PLAN=GenImmix runbms_dacapo2006_with_heap_size fop 20 100
+# Test compressed oops with heap range > 4GB
+MMTK_PLAN=GenImmix runbms_dacapo2006_with_heap_size fop 20 5000
 # Test no compressed oop
 MMTK_PLAN=GenImmix runbms_dacapo2006_with_heap_multiplier fop 4 -XX:-UseCompressedOops -XX:-UseCompressedClassPointers
 

--- a/.github/scripts/ci-test-only-normal.sh
+++ b/.github/scripts/ci-test-only-normal.sh
@@ -40,6 +40,10 @@ run_all 4
 # Test heap resizing
 runbms_dacapo2006_with_heap_size fop 20 100
 
+# Test compressed oops with heap range > 4GB
+# When the heap size is larger than 4GiB, compressed oops will be shifted by 3 bits.
+runbms_dacapo2006_with_heap_size fop 20 5000
+
 # --- StickyImmix ---
 export MMTK_PLAN=StickyImmix
 

--- a/.github/scripts/ci-test-only-normal.sh
+++ b/.github/scripts/ci-test-only-normal.sh
@@ -40,10 +40,6 @@ run_all 4
 # Test heap resizing
 runbms_dacapo2006_with_heap_size fop 20 100
 
-# Test compressed oops with heap range > 4GB
-# When the heap size is larger than 4GiB, compressed oops will be shifted by 3 bits.
-runbms_dacapo2006_with_heap_size fop 20 5000
-
 # --- StickyImmix ---
 export MMTK_PLAN=StickyImmix
 

--- a/openjdk/barriers/mmtkObjectBarrier.cpp
+++ b/openjdk/barriers/mmtkObjectBarrier.cpp
@@ -70,6 +70,7 @@ void MMTkObjectBarrierSetAssembler::object_reference_write_post(MacroAssembler* 
   __ andptr(tmp2, 1);
   __ cmpptr(tmp2, 1);
   __ jcc(Assembler::notEqual, done);
+#endif
 
   __ movptr(c_rarg0, obj);
   __ lea(c_rarg1, dst);
@@ -86,13 +87,11 @@ void MMTkObjectBarrierSetAssembler::object_reference_write_post(MacroAssembler* 
     }
     __ movptr(c_rarg2, val);
   }
-  __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_slow_call), 3);
 
+#if MMTK_ENABLE_BARRIER_FASTPATH
+  __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_slow_call), 3);
   __ bind(done);
 #else
-  __ movptr(c_rarg0, obj);
-  __ lea(c_rarg1, dst);
-  __ movptr(c_rarg2, val == noreg ?  (int32_t) NULL_WORD : val);
   __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_post_call), 3);
 #endif
 }

--- a/openjdk/barriers/mmtkObjectBarrier.hpp
+++ b/openjdk/barriers/mmtkObjectBarrier.hpp
@@ -30,7 +30,7 @@ public:
 
 class MMTkObjectBarrierSetAssembler: public MMTkBarrierSetAssembler {
 protected:
-  virtual void object_reference_write_post(MacroAssembler* masm, DecoratorSet decorators, Address dst, Register val, Register tmp1, Register tmp2) const override;
+  virtual void object_reference_write_post(MacroAssembler* masm, DecoratorSet decorators, Address dst, Register val, Register tmp1, Register tmp2, bool compensate_val_reg) const override;
 public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, BasicType type, Register src, Register dst, Register count) override;
   virtual void arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, BasicType type, Register src, Register dst, Register count) override;

--- a/openjdk/mmtkBarrierSetAssembler_x86.hpp
+++ b/openjdk/mmtkBarrierSetAssembler_x86.hpp
@@ -16,7 +16,8 @@ protected:
   /// Full pre-barrier
   virtual void object_reference_write_pre(MacroAssembler* masm, DecoratorSet decorators, Address dst, Register val, Register tmp1, Register tmp2) const {}
   /// Full post-barrier
-  virtual void object_reference_write_post(MacroAssembler* masm, DecoratorSet decorators, Address dst, Register val, Register tmp1, Register tmp2) const {}
+  /// `compensate_val_reg` is true if this function is called after `BarrierSetAssembler::store_at` which compresses the pointer in the `val` register in place.
+  virtual void object_reference_write_post(MacroAssembler* masm, DecoratorSet decorators, Address dst, Register val, Register tmp1, Register tmp2, bool compensate_val_reg) const {}
 
   /// Barrier elision test
   virtual bool can_remove_barrier(DecoratorSet decorators, Register val, bool skip_const_null) const {
@@ -34,7 +35,9 @@ public:
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type, Address dst, Register val, Register tmp1, Register tmp2) override {
     if (type == T_OBJECT || type == T_ARRAY) object_reference_write_pre(masm, decorators, dst, val, tmp1, tmp2);
     BarrierSetAssembler::store_at(masm, decorators, type, dst, val, tmp1, tmp2);
-    if (type == T_OBJECT || type == T_ARRAY) object_reference_write_post(masm, decorators, dst, val, tmp1, tmp2);
+    // BarrierSetAssembler::store_at modifies val and make it compressed if UseCompressedOops is true.
+    // We need to compensate for this change and decode it in object_reference_write_post.
+    if (type == T_OBJECT || type == T_ARRAY) object_reference_write_post(masm, decorators, dst, val, tmp1, tmp2, true);
   }
 
   /// Generate C1 write barrier slow-call stub


### PR DESCRIPTION
`MMTkBarrierSetAssembler::store_at` calls `object_reference_write_post` after calling `BarrierSetAssembler::store_at`.  However, `BarrierSetAssembler::store_at` modifies the `val` register to compress its value in place.  Consequently, `object_reference_write_post` will see a compressed pointer in the `val` register.

We decompress the pointer in the slow path before calling into MMTk core.  This makes the barrier general, and fixes the assertion error when the compressed `target` value is not aligned, although our current `ObjectBarrier` doesn't use the `slot` and the `target` arguments.

Known issue: The fixed `MMTkObjectBarrierSetAssembler::object_reference_write_post` depends on the internal implementation of the `BarrierSetAssembler::store_at` method in OpenJDK.  However, a general solution needs to save and restore the `val` register before and after calling `BarrierSetAssembler::store_at`, which adds an overhead in the fast path.

Fixes: https://github.com/mmtk/mmtk-openjdk/issues/291