### PR TITLE
Fix a typo in run_all_no_compressed_oop

### DIFF
--- a/.github/scripts/ci-test-only-normal-no-compressed-oops.sh
+++ b/.github/scripts/ci-test-only-normal-no-compressed-oops.sh
@@ -5,7 +5,7 @@ set -xe
 unset JAVA_TOOL_OPTIONS
 
 run_all_no_compressed_oop() {
-    heap_multiplier=$2
+    heap_multiplier=$1
 
     runbms_dacapo2006_with_heap_multiplier antlr $heap_multiplier -XX:-UseCompressedOops -XX:-UseCompressedClassPointers
     runbms_dacapo2006_with_heap_multiplier fop $heap_multiplier -XX:-UseCompressedOops -XX:-UseCompressedClassPointers


### PR DESCRIPTION
This function should take one argument, but it used $2 instead. In previous runs, invocations of run_all_no_compressed_oop have failed silently without making the GitHub-level CI test case `ci-test-only-normal-no-compressed-oops` fail.

This PR fixes the typo.