### PR TITLE
Warn instead of panic when `object_iterate` is called.

### DIFF
--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -315,13 +315,13 @@ GrowableArray<MemoryPool*> MMTkHeap::memory_pools() {//may cause error
 
 // Iterate over all objects, calling "cl.do_object" on each.
 void MMTkHeap::object_iterate(ObjectClosure* cl) { //No need to implement.Traced whole path.Only other heaps call it.
-  guarantee(false, "object iterate not supported");
+  // Not supported.
 }
 
 // Similar to object_iterate() except iterates only
 // over live objects.
 void MMTkHeap::safe_object_iterate(ObjectClosure* cl) { //not sure..many dependencies from vm
-  guarantee(false, "safe object iterate not supported");
+  // Not supported.
 }
 
 HeapWord* MMTkHeap::block_start(const void* addr) const {//OK

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -315,13 +315,13 @@ GrowableArray<MemoryPool*> MMTkHeap::memory_pools() {//may cause error
 
 // Iterate over all objects, calling "cl.do_object" on each.
 void MMTkHeap::object_iterate(ObjectClosure* cl) { //No need to implement.Traced whole path.Only other heaps call it.
-  // Not supported.
+  fprintf(stderr, "WARNING: MMTkHeap::object_iterate is not implemented, yet.");
 }
 
 // Similar to object_iterate() except iterates only
 // over live objects.
 void MMTkHeap::safe_object_iterate(ObjectClosure* cl) { //not sure..many dependencies from vm
-  // Not supported.
+  fprintf(stderr, "WARNING: MMTkHeap::safe_object_iterate is not implemented, yet.");
 }
 
 HeapWord* MMTkHeap::block_start(const void* addr) const {//OK

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -333,13 +333,13 @@ GrowableArray<MemoryPool*> MMTkHeap::memory_pools() {//may cause error
 
 // Iterate over all objects, calling "cl.do_object" on each.
 void MMTkHeap::object_iterate(ObjectClosure* cl) { //No need to implement.Traced whole path.Only other heaps call it.
-  fprintf(stderr, "WARNING: MMTkHeap::object_iterate is not implemented, yet.");
+  fprintf(stderr, "WARNING: MMTkHeap::object_iterate is not implemented, yet.\n");
 }
 
 // Similar to object_iterate() except iterates only
 // over live objects.
 void MMTkHeap::safe_object_iterate(ObjectClosure* cl) { //not sure..many dependencies from vm
-  fprintf(stderr, "WARNING: MMTkHeap::safe_object_iterate is not implemented, yet.");
+  fprintf(stderr, "WARNING: MMTkHeap::safe_object_iterate is not implemented, yet.\n");
 }
 
 HeapWord* MMTkHeap::block_start(const void* addr) const {//OK


### PR DESCRIPTION
The` MMTkHeap` instance will receive calls to `safe_object_iterate` when connected from VisualVM.  If we use `guarantee(...)` to indicate the function is not implemented, the process will abort.  We now give a warning instead.  This does not properly implement the iteration, but will allow the VM to be profiled with VisualVM.