### PR TITLE
Control barrier fast paths via env var

### DIFF
--- a/openjdk/barriers/mmtkObjectBarrier.cpp
+++ b/openjdk/barriers/mmtkObjectBarrier.cpp
@@ -3,37 +3,37 @@
 #include "runtime/interfaceSupport.inline.hpp"
 
 void MMTkObjectBarrierSetRuntime::object_probable_write(oop new_obj) const {
-#if MMTK_ENABLE_BARRIER_FASTPATH
-  // Do fast-path check before entering mmtk rust code, to improve mutator performance.
-  // This is identical to calling `mmtk_object_probable_write` directly without a fast-path.
-  intptr_t addr = (intptr_t) (void*) new_obj;
-  uint8_t* meta_addr = (uint8_t*) (SIDE_METADATA_BASE_ADDRESS + (addr >> 6));
-  intptr_t shift = (addr >> 3) & 0b111;
-  uint8_t byte_val = *meta_addr;
-  if (((byte_val >> shift) & 1) == 1) {
-    // Only promoted objects will reach here.
-    // The duplicated unlog bit check inside slow-path still remains correct.
+  if (mmtk_enable_barrier_fastpath) {
+    // Do fast-path check before entering mmtk rust code, to improve mutator performance.
+    // This is identical to calling `mmtk_object_probable_write` directly without a fast-path.
+    intptr_t addr = (intptr_t) (void*) new_obj;
+    uint8_t* meta_addr = (uint8_t*) (SIDE_METADATA_BASE_ADDRESS + (addr >> 6));
+    intptr_t shift = (addr >> 3) & 0b111;
+    uint8_t byte_val = *meta_addr;
+    if (((byte_val >> shift) & 1) == 1) {
+      // Only promoted objects will reach here.
+      // The duplicated unlog bit check inside slow-path still remains correct.
+      mmtk_object_probable_write((MMTk_Mutator) &Thread::current()->third_party_heap_mutator, (void*) new_obj);
+    }
+  } else {
+    // The slow-call will do the unlog bit check again (same as the above fast-path check)
     mmtk_object_probable_write((MMTk_Mutator) &Thread::current()->third_party_heap_mutator, (void*) new_obj);
   }
-#else
-  // The slow-call will do the unlog bit check again (same as the above fast-path check)
-  mmtk_object_probable_write((MMTk_Mutator) &Thread::current()->third_party_heap_mutator, (void*) new_obj);
-#endif
 }
 
 void MMTkObjectBarrierSetRuntime::object_reference_write_post(oop src, oop* slot, oop target) const {
-#if MMTK_ENABLE_BARRIER_FASTPATH
-  intptr_t addr = (intptr_t) (void*) src;
-  uint8_t* meta_addr = (uint8_t*) (SIDE_METADATA_BASE_ADDRESS + (addr >> 6));
-  intptr_t shift = (addr >> 3) & 0b111;
-  uint8_t byte_val = *meta_addr;
-  if (((byte_val >> shift) & 1) == 1) {
-    // MMTkObjectBarrierSetRuntime::object_reference_write_pre_slow()((void*) src);
-    object_reference_write_slow_call((void*) src, (void*) slot, (void*) target);
+  if (mmtk_enable_barrier_fastpath) {
+    intptr_t addr = (intptr_t) (void*) src;
+    uint8_t* meta_addr = (uint8_t*) (SIDE_METADATA_BASE_ADDRESS + (addr >> 6));
+    intptr_t shift = (addr >> 3) & 0b111;
+    uint8_t byte_val = *meta_addr;
+    if (((byte_val >> shift) & 1) == 1) {
+      // MMTkObjectBarrierSetRuntime::object_reference_write_pre_slow()((void*) src);
+      object_reference_write_slow_call((void*) src, (void*) slot, (void*) target);
+    }
+  } else {
+    object_reference_write_post_call((void*) src, (void*) slot, (void*) target);
   }
-#else
-  object_reference_write_post_call((void*) src, (void*) slot, (void*) target);
-#endif
 }
 
 #define __ masm->
@@ -43,34 +43,33 @@ void MMTkObjectBarrierSetAssembler::object_reference_write_post(MacroAssembler* 
 
   bool is_not_null = (decorators & IS_NOT_NULL) != 0;
 
-  Register obj = dst.base();
-#if MMTK_ENABLE_BARRIER_FASTPATH
   Label done;
+  Register obj = dst.base();
+  if (mmtk_enable_barrier_fastpath) {
+    Register tmp3 = rscratch1;
+    Register tmp4 = rscratch2;
+    assert_different_registers(obj, tmp2, tmp3);
+    assert_different_registers(tmp4, rcx);
 
-  Register tmp3 = rscratch1;
-  Register tmp4 = rscratch2;
-  assert_different_registers(obj, tmp2, tmp3);
-  assert_different_registers(tmp4, rcx);
-
-  // tmp2 = load-byte (SIDE_METADATA_BASE_ADDRESS + (obj >> 6));
-  __ movptr(tmp3, obj);
-  __ shrptr(tmp3, 6);
-  __ movptr(tmp2, SIDE_METADATA_BASE_ADDRESS);
-  __ movb(tmp2, Address(tmp2, tmp3));
-  // tmp3 = (obj >> 3) & 7
-  __ movptr(tmp3, obj);
-  __ shrptr(tmp3, 3);
-  __ andptr(tmp3, 7);
-  // tmp2 = tmp2 >> tmp3
-  __ movptr(tmp4, rcx);
-  __ movl(rcx, tmp3);
-  __ shrptr(tmp2);
-  __ movptr(rcx, tmp4);
-  // if ((tmp2 & 1) == 1) goto slowpath;
-  __ andptr(tmp2, 1);
-  __ cmpptr(tmp2, 1);
-  __ jcc(Assembler::notEqual, done);
-#endif
+    // tmp2 = load-byte (SIDE_METADATA_BASE_ADDRESS + (obj >> 6));
+    __ movptr(tmp3, obj);
+    __ shrptr(tmp3, 6);
+    __ movptr(tmp2, SIDE_METADATA_BASE_ADDRESS);
+    __ movb(tmp2, Address(tmp2, tmp3));
+    // tmp3 = (obj >> 3) & 7
+    __ movptr(tmp3, obj);
+    __ shrptr(tmp3, 3);
+    __ andptr(tmp3, 7);
+    // tmp2 = tmp2 >> tmp3
+    __ movptr(tmp4, rcx);
+    __ movl(rcx, tmp3);
+    __ shrptr(tmp2);
+    __ movptr(rcx, tmp4);
+    // if ((tmp2 & 1) == 1) goto slowpath;
+    __ andptr(tmp2, 1);
+    __ cmpptr(tmp2, 1);
+    __ jcc(Assembler::notEqual, done);
+  }
 
   __ movptr(c_rarg0, obj);
   __ xorptr(c_rarg1, c_rarg1);
@@ -82,12 +81,12 @@ void MMTkObjectBarrierSetAssembler::object_reference_write_post(MacroAssembler* 
   // parameters.
   __ xorptr(c_rarg2, c_rarg2);
 
-#if MMTK_ENABLE_BARRIER_FASTPATH
-  __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_slow_call), 3);
-  __ bind(done);
-#else
-  __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_post_call), 3);
-#endif
+  if (mmtk_enable_barrier_fastpath) {
+    __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_slow_call), 3);
+    __ bind(done);
+  } else {
+    __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_post_call), 3);
+  }
 }
 
 void MMTkObjectBarrierSetAssembler::arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, BasicType type, Register src, Register dst, Register count) {
@@ -178,32 +177,32 @@ void MMTkObjectBarrierSetC1::object_reference_write_post(LIRAccess& access, LIR_
   assert(new_val->is_register(), "must be a register at this point");
   CodeStub* slow = new MMTkC1BarrierStub(src, slot, new_val);
 
-#if MMTK_ENABLE_BARRIER_FASTPATH
-  LIR_Opr addr = src;
-  // uint8_t* meta_addr = (uint8_t*) (SIDE_METADATA_BASE_ADDRESS + (addr >> 6));
-  LIR_Opr offset = gen->new_pointer_register();
-  __ move(addr, offset);
-  __ unsigned_shift_right(offset, 6, offset);
-  LIR_Opr base = gen->new_pointer_register();
-  __ move(LIR_OprFact::longConst(SIDE_METADATA_BASE_ADDRESS), base);
-  LIR_Address* meta_addr = new LIR_Address(base, offset, T_BYTE);
-  // uint8_t byte_val = *meta_addr;
-  LIR_Opr byte_val = gen->new_register(T_INT);
-  __ move(meta_addr, byte_val);
-  // intptr_t shift = (addr >> 3) & 0b111;
-  LIR_Opr shift = gen->new_register(T_INT);
-  __ move(addr, shift);
-  __ unsigned_shift_right(shift, 3, shift);
-  __ logical_and(shift, LIR_OprFact::intConst(0b111), shift);
-  // if (((byte_val >> shift) & 1) == 1) slow;
-  LIR_Opr result = byte_val;
-  __ unsigned_shift_right(result, shift, result, LIR_OprFact::illegalOpr);
-  __ logical_and(result, LIR_OprFact::intConst(1), result);
-  __ cmp(lir_cond_equal, result, LIR_OprFact::intConst(1));
-  __ branch(lir_cond_equal, T_BYTE, slow);
-#else
-  __ jump(slow);
-#endif
+  if (mmtk_enable_barrier_fastpath) {
+    LIR_Opr addr = src;
+    // uint8_t* meta_addr = (uint8_t*) (SIDE_METADATA_BASE_ADDRESS + (addr >> 6));
+    LIR_Opr offset = gen->new_pointer_register();
+    __ move(addr, offset);
+    __ unsigned_shift_right(offset, 6, offset);
+    LIR_Opr base = gen->new_pointer_register();
+    __ move(LIR_OprFact::longConst(SIDE_METADATA_BASE_ADDRESS), base);
+    LIR_Address* meta_addr = new LIR_Address(base, offset, T_BYTE);
+    // uint8_t byte_val = *meta_addr;
+    LIR_Opr byte_val = gen->new_register(T_INT);
+    __ move(meta_addr, byte_val);
+    // intptr_t shift = (addr >> 3) & 0b111;
+    LIR_Opr shift = gen->new_register(T_INT);
+    __ move(addr, shift);
+    __ unsigned_shift_right(shift, 3, shift);
+    __ logical_and(shift, LIR_OprFact::intConst(0b111), shift);
+    // if (((byte_val >> shift) & 1) == 1) slow;
+    LIR_Opr result = byte_val;
+    __ unsigned_shift_right(result, shift, result, LIR_OprFact::illegalOpr);
+    __ logical_and(result, LIR_OprFact::intConst(1), result);
+    __ cmp(lir_cond_equal, result, LIR_OprFact::intConst(1));
+    __ branch(lir_cond_equal, T_BYTE, slow);
+  } else {
+    __ jump(slow);
+  }
 
   __ branch_destination(slow->continuation());
 }
@@ -217,26 +216,26 @@ void MMTkObjectBarrierSetC2::object_reference_write_post(GraphKit* kit, Node* sr
 
   MMTkIdealKit ideal(kit, true);
 
-#if MMTK_ENABLE_BARRIER_FASTPATH
-  Node* no_base = __ top();
-  float unlikely  = PROB_UNLIKELY(0.999);
+  if (mmtk_enable_barrier_fastpath) {
+    Node* no_base = __ top();
+    float unlikely  = PROB_UNLIKELY(0.999);
 
-  Node* zero  = __ ConI(0);
-  Node* addr = __ CastPX(__ ctrl(), src);
-  Node* meta_addr = __ AddP(no_base, __ ConP(SIDE_METADATA_BASE_ADDRESS), __ URShiftX(addr, __ ConI(6)));
-  Node* byte = __ load(__ ctrl(), meta_addr, TypeInt::INT, T_BYTE, Compile::AliasIdxRaw);
-  Node* shift = __ URShiftX(addr, __ ConI(3));
-  shift = __ AndI(__ ConvL2I(shift), __ ConI(7));
-  Node* result = __ AndI(__ URShiftI(byte, shift), __ ConI(1));
+    Node* zero  = __ ConI(0);
+    Node* addr = __ CastPX(__ ctrl(), src);
+    Node* meta_addr = __ AddP(no_base, __ ConP(SIDE_METADATA_BASE_ADDRESS), __ URShiftX(addr, __ ConI(6)));
+    Node* byte = __ load(__ ctrl(), meta_addr, TypeInt::INT, T_BYTE, Compile::AliasIdxRaw);
+    Node* shift = __ URShiftX(addr, __ ConI(3));
+    shift = __ AndI(__ ConvL2I(shift), __ ConI(7));
+    Node* result = __ AndI(__ URShiftI(byte, shift), __ ConI(1));
 
-  __ if_then(result, BoolTest::ne, zero, unlikely); {
+    __ if_then(result, BoolTest::ne, zero, unlikely); {
+      const TypeFunc* tf = __ func_type(TypeOopPtr::BOTTOM, TypeOopPtr::BOTTOM, TypeOopPtr::BOTTOM);
+      Node* x = __ make_leaf_call(tf, FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_slow_call), "mmtk_barrier_call", src, slot, val);
+    } __ end_if();
+  } else {
     const TypeFunc* tf = __ func_type(TypeOopPtr::BOTTOM, TypeOopPtr::BOTTOM, TypeOopPtr::BOTTOM);
-    Node* x = __ make_leaf_call(tf, FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_slow_call), "mmtk_barrier_call", src, slot, val);
-  } __ end_if();
-#else
-  const TypeFunc* tf = __ func_type(TypeOopPtr::BOTTOM, TypeOopPtr::BOTTOM, TypeOopPtr::BOTTOM);
-  Node* x = __ make_leaf_call(tf, FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_post_call), "mmtk_barrier_call", src, slot, val);
-#endif
+    Node* x = __ make_leaf_call(tf, FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_post_call), "mmtk_barrier_call", src, slot, val);
+  }
 
   kit->final_sync(ideal); // Final sync IdealKit and GraphKit.
 }

--- a/openjdk/mmtkBarrierSet.cpp
+++ b/openjdk/mmtkBarrierSet.cpp
@@ -35,6 +35,9 @@
 #include "mmtkBarrierSetC2.hpp"
 #endif
 
+bool mmtk_enable_allocation_fastpath = true;
+bool mmtk_enable_barrier_fastpath = true;
+
 MMTkAllocatorOffsets get_tlab_top_and_end_offsets(AllocatorSelector selector) {
   int tlab_top_offset, tlab_end_offset;
   int allocators_base_offset = in_bytes(JavaThread::third_party_heap_mutator_offset())

--- a/openjdk/mmtkBarrierSet.hpp
+++ b/openjdk/mmtkBarrierSet.hpp
@@ -37,8 +37,8 @@
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/fakeRttiSupport.hpp"
 
-#define MMTK_ENABLE_ALLOCATION_FASTPATH true
-#define MMTK_ENABLE_BARRIER_FASTPATH true
+extern bool mmtk_enable_allocation_fastpath;
+extern bool mmtk_enable_barrier_fastpath;
 
 const intptr_t VO_BIT_BASE_ADDRESS = VO_BIT_ADDRESS;
 

--- a/openjdk/mmtkBarrierSetAssembler_x86.cpp
+++ b/openjdk/mmtkBarrierSetAssembler_x86.cpp
@@ -39,7 +39,7 @@ void MMTkBarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register threa
   assert(obj == rax, "obj must be in rax, for cmpxchg");
   assert_different_registers(obj, var_size_in_bytes, t1);
 
-  if (!MMTK_ENABLE_ALLOCATION_FASTPATH) {
+  if (!mmtk_enable_allocation_fastpath) {
     __ jmp(slow_case);
   } else {
     // MMTk size check. If the alloc size is larger than the allowed max size for non los,
@@ -164,11 +164,11 @@ void MMTkBarrierSetAssembler::generate_c1_write_barrier_runtime_stub(StubAssembl
 
   __ save_live_registers_no_oop_map(true);
 
-#if MMTK_ENABLE_BARRIER_FASTPATH
-  __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_slow_call), 3);
-#else
-  __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_post_call), 3);
-#endif
+  if (mmtk_enable_barrier_fastpath) {
+    __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_slow_call), 3);
+  } else {
+    __ call_VM_leaf_base(FN_ADDR(MMTkBarrierSetRuntime::object_reference_write_post_call), 3);
+  }
 
   __ restore_live_registers(true);
 

--- a/openjdk/mmtkBarrierSetC2.cpp
+++ b/openjdk/mmtkBarrierSetC2.cpp
@@ -130,7 +130,7 @@ void MMTkBarrierSetC2::expand_allocate(PhaseMacroExpand* x,
     }
   }
 
-  if (x->C->env()->dtrace_alloc_probes() || !MMTK_ENABLE_ALLOCATION_FASTPATH
+  if (x->C->env()->dtrace_alloc_probes() || !mmtk_enable_allocation_fastpath
       // Malloc allocator has no fastpath
       || (selector.tag == TAG_MALLOC || selector.tag == TAG_LARGE_OBJECT || selector.tag == TAG_FREE_LIST)) {
     // Force slow-path allocation
@@ -600,7 +600,7 @@ bool MMTkBarrierSetC2::can_remove_barrier(GraphKit* kit, PhaseTransform* phase, 
     return true;
   }
   // Barrier elision based on allocation node does not working well with slowpath-only allocation.
-  if (!MMTK_ENABLE_ALLOCATION_FASTPATH) return false;
+  if (!mmtk_enable_allocation_fastpath) return false;
   // No barrier required for newly allocated objects.
   if (src == kit->just_allocated_object(kit->control())) return true;
 

--- a/openjdk/mmtkHeap.cpp
+++ b/openjdk/mmtkHeap.cpp
@@ -75,8 +75,26 @@ MMTkHeap::MMTkHeap(MMTkCollectorPolicy* policy) :
   _heap = this;
 }
 
+static void set_bool_option_from_env_var(const char *name, bool *var) {
+  const char *env_var = getenv(name);
+  if (env_var != NULL) {
+    if (strcmp(env_var, "true") == 0 || strcmp(env_var, "yes") == 0 || strcmp(env_var, "on") == 0 || strcmp(env_var, "1") == 0) {
+      *var = true;
+    } else if (strcmp(env_var, "false") == 0 || strcmp(env_var, "no") == 0 || strcmp(env_var, "off") == 0 || strcmp(env_var, "0") == 0) {
+      *var = false;
+    } else {
+      fprintf(stderr, "Unexpected value for env var %s: %s\n", name, env_var);
+      abort();
+    }
+  }
+}
+
 jint MMTkHeap::initialize() {
   assert(!UseTLAB , "should disable UseTLAB");
+
+  set_bool_option_from_env_var("MMTK_ENABLE_ALLOCATION_FASTPATH", &mmtk_enable_allocation_fastpath);
+  set_bool_option_from_env_var("MMTK_ENABLE_BARRIER_FASTPATH", &mmtk_enable_barrier_fastpath);
+
   const size_t min_heap_size = collector_policy()->min_heap_byte_size();
   const size_t max_heap_size = collector_policy()->max_heap_byte_size();
   //  printf("policy max heap size %zu, min heap size %zu\n", heap_size, collector_policy()->min_heap_byte_size());

--- a/openjdk/mmtkHeap.hpp
+++ b/openjdk/mmtkHeap.hpp
@@ -101,7 +101,7 @@ public:
   bool supports_tlab_allocation() const;
 
   bool supports_inline_contig_alloc() const {
-    return MMTK_ENABLE_ALLOCATION_FASTPATH;
+    return mmtk_enable_allocation_fastpath;
   }
 
   // The amount of space available for thread-local allocation buffers.


### PR DESCRIPTION
This makes it easier to debug because we can compare the performance with or without inlining the allocation and write-barrier fast paths without recompiling OpenJDK.