### PR TITLE
Reduce the test heap size for concurrent immix

### DIFF
--- a/.github/configs/large-heap.yml
+++ b/.github/configs/large-heap.yml
@@ -1,9 +1,0 @@
-includes:
-  - "./base.yml"
-
-configs:
-  - "jdk11-master|ms|s|fail_on_oom|tph|preserve|mmtk_gc-ConcurrentImmix"
-
-# This will be expanded in CI when we run with the config. Keep a new line at the end.
-benchmarks:
-  dacapo-23.9-RC3-chopin-ci:

--- a/.github/configs/normal-heap.yml
+++ b/.github/configs/normal-heap.yml
@@ -10,6 +10,7 @@ configs:
   - "jdk11-master|ms|s|fail_on_oom|tph|preserve|mmtk_gc-MarkSweep"
   - "jdk11-master|ms|s|fail_on_oom|tph|preserve|mmtk_gc-MarkCompact"
   - "jdk11-master|ms|s|fail_on_oom|tph|preserve|mmtk_gc-Compressor"
+  - "jdk11-master|ms|s|fail_on_oom|tph|preserve|mmtk_gc-ConcurrentImmix"
 
 # This will be expanded in CI when we run with the config. Keep a new line at the end.
 benchmarks:

--- a/.github/workflows/run-dacapo-chopin.yml
+++ b/.github/workflows/run-dacapo-chopin.yml
@@ -14,4 +14,4 @@ jobs:
     uses: ./.github/workflows/run-dacapo-chopin-inner.yml
     with:
       config-file: "large-heap.yml"
-      heap-factor: "7"
+      heap-factor: "2.5"

--- a/.github/workflows/run-dacapo-chopin.yml
+++ b/.github/workflows/run-dacapo-chopin.yml
@@ -10,8 +10,9 @@ jobs:
       config-file: "normal-heap.yml"
       heap-factor: "2.5"
 
-  large-heap:
-    uses: ./.github/workflows/run-dacapo-chopin-inner.yml
-    with:
-      config-file: "large-heap.yml"
-      heap-factor: "2.5"
+  # In case that we need to run some plans with a larger heap, we can use a different config file.
+  # large-heap:
+  #   uses: ./.github/workflows/run-dacapo-chopin-inner.yml
+  #   with:
+  #     config-file: "large-heap.yml"
+  #     heap-factor: "7"


### PR DESCRIPTION
The heap size for concurrent immix was set to 7x, as initially it was non-moving. Later we allowed moving for the full pause in concurrent Immix. This PR reduces the heap size for our concurrent immix tests.