### PR TITLE
Fix mismatching Klass definition

### DIFF
--- a/mmtk/src/abi.rs
+++ b/mmtk/src/abi.rs
@@ -85,6 +85,7 @@ pub struct Klass {
     pub access_flags: i32, // AccessFlags
     #[cfg(feature = "jfr")]
     pub trace_id: u64, // JFR_ONLY(traceid _trace_id;)
+    pub shared_class_path_index: i16,
     pub shared_class_flags: u16,
     pub archived_mirror_index: i32,
     pub padding: i32,


### PR DESCRIPTION
There is one field missing in the Rust definition of `Klass`.  The current code happens to work because the compiler added alignment padding.

Fixes: https://github.com/mmtk/mmtk-openjdk/issues/344