### PR TITLE
Add configurations for mergify to allow backporting to jdk-11

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: backport to jdk-11
+    conditions:
+      - base=jdk-21
+      - label=backport-jdk-11
+    actions:
+      backport:
+        branches:
+          - jdk-11
+        assignees:
+          - "{{ author }}"
+        label_conflicts: backport-conflicts


### PR DESCRIPTION
Copied from mmtk-julia's configuration: https://github.com/mmtk/mmtk-julia/blob/master/.github/mergify.yml. 

When a PR that is based on `jdk-21` with a label `backport-jdk-11` is merged, a PR based on `jdk-11` will be created by cherry-picking the changes.