### PR TITLE
Use actions/cache@v4. Set max parallel to 10

### DIFF
--- a/.github/workflows/run-dacapo-chopin-inner.yml
+++ b/.github/workflows/run-dacapo-chopin-inner.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Check ${{ env.DACAPO_VERSION }} cache
         id: check-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dacapo/${{ env.DACAPO_FILE }}
           key: ${{ env.DACAPO_VERSION }}
@@ -42,6 +42,10 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
+      # Cap concurrent legs so they don't all restore the 6.3 GB DaCapo
+      # cache entry at once (that concurrent load is what causes the
+      # intermittent download failures/stalls).
+      max-parallel: 10
       matrix:
         debug-level: ["fastdebug", "release"]
         benchmark:
@@ -98,7 +102,7 @@ jobs:
           # df /home/runner/runners
       - name: Fetch ${{ env.DACAPO_VERSION }} cache
         id: fetch-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dacapo/${{ env.DACAPO_FILE }}
           key: ${{ env.DACAPO_VERSION }}


### PR DESCRIPTION
We saw intermittent errors when restoring dacapo cache in our CI. Those jobs failed at the step of 'Fetch dacapo-23.11-MR2-chopin cache' with half downloaded dacapo from cache. 

This PR updates the cache action to v4, and limit the max parallel job to 10 for the testing. Instead of having 34 jobs downloading the 6GB dacapo jar from cache, we will only have 10 concurrent jobs downloading from cache. Hopefully this will improve the stability.