### PR TITLE
Swap the maximize-build-space action to free-disk-space

### DIFF
--- a/.github/workflows/run-dacapo-chopin-inner.yml
+++ b/.github/workflows/run-dacapo-chopin-inner.yml
@@ -70,17 +70,16 @@ jobs:
     steps:
       - name: Check free space
         run: df -h
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
-          remove-docker-images: true
-          # Leave some room for the runner for logging in /dev/root
-          root-reserve-mb: 6000
-          temp-reserve-mb: 1024
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          tool-cache: true
+          swap-storage: true
       - name: Check free space
         run: df -h
       - name: Checkout MMTk OpenJDK binding


### PR DESCRIPTION
We frequently see some jobs hung while fetching Dacapo cache. The error from the runner indicated that this is due to out-of-space.

We use `maximize-build-space` to get more disk space for Github runner. But it seems the action is not very effective (https://github.com/easimon/maximize-build-space/issues/44), and may even reduce the available disk space (https://github.com/easimon/maximize-build-space/issues/55). This PR replaces `maximize-build-space` with a different action `free-disk-space`. It seems no out-of-disk in the current runs.