### PR TITLE
Use the Dacapo Chopin minimal zip for CI

### DIFF
--- a/.github/configs/base.yml
+++ b/.github/configs/base.yml
@@ -8,7 +8,7 @@ suites:
   dacapochopin:
     type: DaCapo
     release: "23.11"
-    path: "DACAPO_PATH/dacapo-23.11-MR2-chopin.jar"
+    path: "DACAPO_PATH/dacapo-23.11-MR2-chopin-minimal.jar"
     minheap: mmtk-openjdk-11-Lisp2
     # Min heap values are from dacapo-evaluation-git-04132797
     # TODO: Use the values provided by the released version, and use G1 instead of Lisp2.

--- a/.github/workflows/run-dacapo-chopin-inner.yml
+++ b/.github/workflows/run-dacapo-chopin-inner.yml
@@ -13,9 +13,10 @@ on:
         type: string
 
 env:
-  DACAPO_VERSION: dacapo-23.11-MR2-chopin
-  DACAPO_FILE: dacapo-23.11-MR2-chopin.zip
-  DACAPO_DOWNLOAD_URL: https://download.dacapobench.org/chopin/dacapo-23.11-MR2-chopin.zip
+  # Minimal variant (~1.4GB) instead of the full zip (~6.3GB).
+  DACAPO_VERSION: dacapo-23.11-MR2-chopin-minimal
+  DACAPO_FILE: dacapo-23.11-MR2-chopin-minimal.zip
+  DACAPO_DOWNLOAD_URL: https://download.dacapobench.org/chopin/dacapo-23.11-MR2-chopin-minimal.zip
 
 jobs:
   cache-dacapo:


### PR DESCRIPTION
As @k-sareen suggsted in https://github.com/mmtk/mmtk-openjdk/pull/367#issuecomment-5235111735, we can use a minimal dacapo chopin zip in our CI (1.4G), instead of the full zip (6.3G).