### PR TITLE
No longer report pmd digest verification fail

### DIFF
--- a/.github/scripts/ci-matrix-result-check.py
+++ b/.github/scripts/ci-matrix-result-check.py
@@ -95,7 +95,7 @@ def read_in_expected_results(build, benchmark):
 
     return data["results"][arch][build][benchmark]
 
-def print_log(directory, search_string):
+def read_log(directory, search_string):
     import gzip
 
     # Check if the provided path is a directory
@@ -103,25 +103,53 @@ def print_log(directory, search_string):
         print(f"Error: {directory} is not a directory.")
         sys.exit(1)
 
-    # Walk through the directory
+    # Walk through the directory and concatenate the content of any matching log.gz files
+    content = ""
     for root, dirs, files in os.walk(directory):
         for file in files:
-            if search_string in file:
+            if search_string in file and file.endswith('log.gz'):
                 file_path = os.path.join(root, file)
-                # Check if the file has a .gz extension
-                if file_path.endswith('log.gz'):
-                    with gzip.open(file_path, 'rt') as f:
-                        content = f.read()
-                        print(f"----------------------------------------------")
-                        print(f"START: {file_path}")
-                        print(content)
-                        print(f"END: {file_path}")
-                        print(f"----------------------------------------------")
+                with gzip.open(file_path, 'rt') as f:
+                    content += f.read()
+    return content
+
+def print_log(directory, search_string):
+    content = read_log(directory, search_string)
+    print(f"----------------------------------------------")
+    print(f"START: {search_string}")
+    print(content)
+    print(f"END: {search_string}")
+    print(f"----------------------------------------------")
+
+# pmd's own multi-threaded analysis has a known, pre-existing data race
+# (unsynchronized "sig" field) that occasionally makes it throw a
+# NullPointerException instead of reporting a lint violation, which changes
+# pmd-report.txt just enough to fail DaCapo's digest check. This reproduces
+# with stock OpenJDK/GraalVM with no MMTk involvement at all -- see
+# https://github.com/dacapobench/dacapobench/issues/310. It is not a real
+# test failure, so we ignore it here rather than flaking the whole CI run.
+def is_pmd_digest_only_failure(directory, plan):
+    # Match "mmtk_gc-{plan}." rather than a bare substring, otherwise e.g.
+    # plan "Immix" would also match the log files for "GenImmix",
+    # "StickyImmix" and "ConcurrentImmix".
+    content = read_log(directory, f"mmtk_gc-{plan}.")
+    return "Digest validation failed for pmd-report.txt" in content
 
 # dict['a'] = 'SemiSpace', etc
 plan_dict = read_in_plans(config_file)
 
 actual = read_in_actual_results(sys.stdin.readline(), plan_dict)
+
+if benchmark == "pmd":
+    for plan, result in actual.items():
+        if result == "fail" and is_pmd_digest_only_failure(log_dir, plan):
+            print(
+                f"Note: {plan} failed pmd's pmd-report.txt digest check. This is a known "
+                f"upstream PMD data race unrelated to MMTk "
+                f"(see https://github.com/dacapobench/dacapobench/issues/310); treating it as a pass."
+            )
+            actual[plan] = "pass"
+
 expected = read_in_expected_results(build, benchmark)
 
 print("Expected:")
@@ -156,6 +184,8 @@ for plan in expected:
 print(f"\nPrint logs for all failed runs: {failed_plans}\n")
 
 for failed_plan in failed_plans:
-    print_log(log_dir, failed_plan)
+    # See is_pmd_digest_only_failure() for why we match "mmtk_gc-{plan}." rather
+    # than a bare substring.
+    print_log(log_dir, f"mmtk_gc-{failed_plan}.")
 
 exit(error_no)


### PR DESCRIPTION
Related to https://github.com/mmtk/mmtk-openjdk/issues/262. Not showing the benchmark as fail in our CI, if we see the same error.

Done by Claude.