### PR TITLE
Use --no-validation for dacapo when running pmd

### DIFF
--- a/.github/configs/base.yml
+++ b/.github/configs/base.yml
@@ -80,6 +80,20 @@ modifiers:
   no_compressed_oops:
     type: JVMArg
     val: "-XX:-UseCompressedOops -XX:-UseCompressedClassPointers"
+  pmd_no_validation:
+    # pmd's own multi-threaded analysis has a known, pre-existing data race
+    # (unsynchronized "sig" field) that occasionally makes it throw a
+    # NullPointerException instead of reporting a lint violation. This changes
+    # pmd-report.txt just enough to fail DaCapo's digest check, even though
+    # nothing is actually wrong. This reproduces with stock OpenJDK/GraalVM
+    # with no MMTk involvement at all -- see
+    # https://github.com/dacapobench/dacapobench/issues/310. GraalVM works
+    # around it the same way: https://github.com/oracle/graal/commit/531528724b71131a3fadfa10288ccb8c28bc6482
+    type: ProgramArg
+    val: "--no-validation"
+    includes:
+      dacapochopin:
+        - pmd
 
 plugins:
   keep_stdout_stderr:

--- a/.github/configs/normal-heap.yml
+++ b/.github/configs/normal-heap.yml
@@ -2,15 +2,15 @@ includes:
   - "./base.yml"
 
 configs:
-  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|mmtk_gc-SemiSpace"
-  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|mmtk_gc-GenCopy"
-  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|mmtk_gc-Immix"
-  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|mmtk_gc-GenImmix"
-  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|mmtk_gc-StickyImmix"
-  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|mmtk_gc-MarkSweep"
-  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|mmtk_gc-Lisp2"
-  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|mmtk_gc-OVC"
-  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|mmtk_gc-ConcurrentImmix"
+  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|pmd_no_validation|mmtk_gc-SemiSpace"
+  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|pmd_no_validation|mmtk_gc-GenCopy"
+  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|pmd_no_validation|mmtk_gc-Immix"
+  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|pmd_no_validation|mmtk_gc-GenImmix"
+  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|pmd_no_validation|mmtk_gc-StickyImmix"
+  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|pmd_no_validation|mmtk_gc-MarkSweep"
+  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|pmd_no_validation|mmtk_gc-Lisp2"
+  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|pmd_no_validation|mmtk_gc-OVC"
+  - "jdk21-master|dacapochopin_jdk21|ms|s|fail_on_oom|tph|preserve|pmd_no_validation|mmtk_gc-ConcurrentImmix"
 
 # This will be expanded in CI when we run with the config. Keep a new line at the end.
 benchmarks:


### PR DESCRIPTION
Related to https://github.com/mmtk/mmtk-openjdk/issues/262. Skip digest validation for pmd.

Done by Claude.