### PR TITLE
Move FixRelocations back to SoftRefClosure stage

### DIFF
--- a/mmtk/src/gc_work.rs
+++ b/mmtk/src/gc_work.rs
@@ -177,7 +177,7 @@ impl<const COMPRESSED: bool, F: RootsWorkFactory<OpenJDKSlot<COMPRESSED>>>
                 // For scavenging GCs, the mmtk-openjdk binding reports the *slots* of nmethods as
                 // roots. They will be traced at unspecified times during the Closure stage.
                 // SoftRefClosure is the first safe place to call fix_oop_relocations.
-                WorkBucketStage::Release
+                WorkBucketStage::SoftRefClosure
             };
             worker.scheduler().work_buckets[stage].bulk_add(packets);
         }


### PR DESCRIPTION
It was changed to the Release stage in the LXR pull request.

We revert this change so that it still executes the `FixRelocations` work packet in the `SoftRefClosure` bucket, which is the bucket right after the `Closure` bucket.  Delayed-copy collectors (mark-compact) are not changed.  They still executes `FixRelocations` in the `RefForwarding` stage.